### PR TITLE
greatly improve speed of building opscode cache

### DIFF
--- a/lib/berkshelf/api/cache_builder/worker.rb
+++ b/lib/berkshelf/api/cache_builder/worker.rb
@@ -47,7 +47,7 @@ module Berkshelf::API
               log.info "#{self} cache is stale."
               log.info "#{self} adding (#{diff[0].length}) items..."
               log.info "#{self} removing (#{diff[1].length}) items..."
-              defer { update_cache }
+              update_cache
               log.info "#{self} cache updated."
             else
               log.info "#{self} cache is up to date."
@@ -67,8 +67,11 @@ module Berkshelf::API
           created_cookbooks, deleted_cookbooks = diff
 
           created_cookbooks.collect do |remote|
-            cache_manager.future(:add, remote.name, remote.version, metadata(remote))
-          end.map(&:value)
+            [ remote, future(:metadata, remote) ]
+          end.each do |remote, metadata|
+            cache_manager.add(remote.name, remote.version, metadata.value)
+          end
+
           deleted_cookbooks.each { |remote| cache_manager.remove(remote.name, remote.version) }
         end
 

--- a/lib/berkshelf/api/cache_builder/worker.rb
+++ b/lib/berkshelf/api/cache_builder/worker.rb
@@ -45,10 +45,7 @@ module Berkshelf::API
             log.info "#{self} determining if the cache is stale..."
             if stale?
               log.info "#{self} cache is stale."
-              log.info "#{self} adding (#{diff[0].length}) items..."
-              log.info "#{self} removing (#{diff[1].length}) items..."
               update_cache
-              log.info "#{self} cache updated."
             else
               log.info "#{self} cache is up to date."
             end
@@ -66,13 +63,18 @@ module Berkshelf::API
         def update_cache
           created_cookbooks, deleted_cookbooks = diff
 
+          log.info "#{self} adding (#{created_cookbooks.length}) items..."
           created_cookbooks.collect do |remote|
             [ remote, future(:metadata, remote) ]
           end.each do |remote, metadata|
             cache_manager.add(remote.name, remote.version, metadata.value)
           end
 
+          log.info "#{self} removing (#{deleted_cookbooks.length}) items..."
           deleted_cookbooks.each { |remote| cache_manager.remove(remote.name, remote.version) }
+
+          log.info "#{self} cache updated."
+          cache_manager.save
         end
 
         def stale?

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -1,6 +1,13 @@
 module Berkshelf::API
   class CacheManager
     class << self
+      attr_writer :cache_file
+
+      # @return [String]
+      def cache_file
+        @cache_file ||= File.expand_path("~/.berkshelf/api-server/cerch")
+      end
+
       # @raise [Celluloid::DeadActorError] if Bootstrap Manager has not been started
       #
       # @return [Celluloid::Actor(Berkshelf::API::CacheManager)]
@@ -40,7 +47,7 @@ module Berkshelf::API
     def initialize
       log.info "Cache Manager starting..."
       @cache = DependencyCache.new
-      load_save if File.exist?(save_file)
+      load_save if File.exist?(self.class.cache_file)
     end
 
     # @param [String] name
@@ -53,7 +60,7 @@ module Berkshelf::API
     end
 
     def load_save
-      @cache = DependencyCache.from_file(save_file)
+      @cache = DependencyCache.from_file(self.class.cache_file)
     end
 
     # @param [String] name
@@ -65,13 +72,9 @@ module Berkshelf::API
     end
 
     def save
-      log.info "Saving the cache to: #{save_file}"
-      cache.save(save_file)
+      log.info "Saving the cache to: #{self.class.cache_file}"
+      cache.save(self.class.cache_file)
       log.info "Cache saved!"
-    end
-
-    def save_file
-      File.expand_path("~/.berkshelf/api-server/cerch")
     end
 
     # @param [Array<RemoteCookbook>] cookbooks

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -64,6 +64,12 @@ module Berkshelf::API
       @cache.remove(name, version)
     end
 
+    def save
+      log.info "Saving the cache to: #{save_file}"
+      cache.save(save_file)
+      log.info "Cache saved!"
+    end
+
     def save_file
       File.expand_path("~/.berkshelf/api-server/cerch")
     end
@@ -86,9 +92,7 @@ module Berkshelf::API
 
       def finalize_callback
         log.info "Cache Manager shutting down..."
-        log.info "Saving the cache to: #{save_file}"
-        cache.save(save_file)
-        log.info "Cache saved!"
+        self.save
       end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ Spork.prefork do
     config.before do
       Celluloid.shutdown
       Celluloid.boot
+      Berkshelf::API::CacheManager.cache_file = tmp_path.join('cerch').to_s
       clean_tmp_path
     end
   end

--- a/spec/unit/berkshelf/api/cache_builder/worker/opscode_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker/opscode_spec.rb
@@ -7,8 +7,6 @@ describe Berkshelf::API::CacheBuilder::Worker::Opscode do
   let(:connection) do
     connection = double('connection')
     connection.stub(:cookbooks).and_return(cookbooks)
-    connection.stub(:versions).with("chicken").and_return(chicken_versions)
-    connection.stub(:versions).with("tuna").and_return(tuna_versions)
     connection
   end
 
@@ -26,18 +24,9 @@ describe Berkshelf::API::CacheBuilder::Worker::Opscode do
         Berkshelf::API::RemoteCookbook.new("tuna", "3.0.1"),
       ]
 
+      connection.should_receive(:future).with(:versions, "chicken").and_return(double(value: chicken_versions))
+      connection.should_receive(:future).with(:versions, "tuna").and_return(double(value: tuna_versions))
       subject.should_receive(:connection).at_least(1).times.and_return(connection)
-      expect(subject.cookbooks).to eql(expected_value)
-    end
-
-    it "respects options[:get_only] to limit the number of cookbooks requested" do
-      expected_value = [
-        Berkshelf::API::RemoteCookbook.new("chicken", "1.0"),
-        Berkshelf::API::RemoteCookbook.new("chicken", "2.0"),
-      ]
-
-      subject.should_receive(:connection).at_least(1).times.and_return(connection)
-      subject.should_receive(:options).and_return({:get_only => 1})
       expect(subject.cookbooks).to eql(expected_value)
     end
   end

--- a/spec/unit/berkshelf/api/cache_manager_spec.rb
+++ b/spec/unit/berkshelf/api/cache_manager_spec.rb
@@ -9,7 +9,7 @@ describe Berkshelf::API::CacheManager do
       context "when a save file exists" do
         before do
           @tempfile = Tempfile.new('berkshelf-api-rspec')
-          described_class.any_instance.stub(:save_file) { @tempfile.path }
+          described_class.stub(:cache_file) { @tempfile.path }
         end
         after { @tempfile.close(true) }
 
@@ -20,7 +20,7 @@ describe Berkshelf::API::CacheManager do
       end
 
       context "when a save file does not exist" do
-        before { described_class.any_instance.stub(save_file: tmp_path.join('does_not_exist').to_s) }
+        before { described_class.stub(cache_file: tmp_path.join('does_not_exist').to_s) }
 
         it "skips loading of the saved cache" do
           described_class.any_instance.should_not_receive(:load_save)


### PR DESCRIPTION
This reduces the cache stale check to ~12 seconds. It also will improve the speed of downloading and reading the metadata of cookbooks once we know the cache difference.
