### PR TITLE
option parsing for berks-api binary moved to Berkshelf::API::SrvCtl

### DIFF
--- a/bin/berks-api
+++ b/bin/berks-api
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 $:.push File.expand_path("../../lib", __FILE__)
-require 'berkshelf/api'
+require 'berkshelf/api/srv_ctl'
 
 Berkshelf::API::SrvCtl.run(ARGV, File.basename(__FILE__))

--- a/bin/berks-api
+++ b/bin/berks-api
@@ -2,4 +2,4 @@
 $:.push File.expand_path("../../lib", __FILE__)
 require 'berkshelf/api'
 
-Berkshelf::API::Application.run(ARGV)
+Berkshelf::API::SrvCtl.run(ARGV, File.basename(__FILE__))

--- a/lib/berkshelf/api.rb
+++ b/lib/berkshelf/api.rb
@@ -26,3 +26,5 @@ module Berkshelf
     autoload :SiteConnector, 'berkshelf/api/site_connector'
   end
 end
+
+require_relative 'api/srv_ctl'

--- a/lib/berkshelf/api/logging.rb
+++ b/lib/berkshelf/api/logging.rb
@@ -5,7 +5,7 @@ module Berkshelf::API
       attr_accessor :logger
 
       # @option options [String, Fixnum] :location (STDOUT)
-      # @option options [String] :level ("INFO")
+      # @option options [String, nil] :level ("INFO")
       #   - "DEBUG
       #   - "INFO"
       #   - "WARN"
@@ -15,11 +15,13 @@ module Berkshelf::API
       #
       # @return [Logger]
       def init(options = {})
-        options = { location: STDOUT, level: "INFO" }.merge(options)
+        level     = options[:level] || "INFO"
+        location  = options[:location] || STDOUT
+        formatter = options[:formatter] || nil
 
-        Celluloid.logger = @logger = Logger.new(options[:location]).tap do |log|
-          log.level     = Logger::Severity.const_get(options[:level])
-          log.formatter = options[:formatter] if options[:formatter]
+        Celluloid.logger = @logger = Logger.new(location).tap do |log|
+          log.level     = Logger::Severity.const_get(level.upcase)
+          log.formatter = formatter if formatter
         end
       end
     end

--- a/lib/berkshelf/api/srv_ctl.rb
+++ b/lib/berkshelf/api/srv_ctl.rb
@@ -1,4 +1,5 @@
 require 'optparse'
+require 'buff/extensions'
 
 module Berkshelf::API
   class SrvCtl
@@ -52,6 +53,7 @@ module Berkshelf::API
     end
 
     def start
+      require 'berkshelf/api'
       Berkshelf::API::Application.run(options)
     end
   end

--- a/lib/berkshelf/api/srv_ctl.rb
+++ b/lib/berkshelf/api/srv_ctl.rb
@@ -1,0 +1,58 @@
+require 'optparse'
+
+module Berkshelf::API
+  class SrvCtl
+    class << self
+      # @param [Array] args
+      #
+      # @return [Hash]
+      def parse_options(args, filename)
+        options = Hash.new
+
+        OptionParser.new("Usage: #{filename} [options]") do |opts|
+          opts.on("-p", "--port PORT", Integer, "set the listening port") do |v|
+            options[:port] = v
+          end
+
+          opts.on("-v", "--verbose", "run with verbose output") do
+            options[:log_level] = "INFO"
+          end
+
+          opts.on("-d", "--debug", "run with debug output") do
+            options[:log_level] = "DEBUG"
+          end
+
+          opts.on("-q", "--quiet", "silence output") do
+            options[:log_location] = '/dev/null'
+          end
+
+          opts.on_tail("-h", "--help", "show this message") do
+            puts opts
+            exit
+          end
+        end.parse!(args)
+
+        options.symbolize_keys
+      end
+
+      # @param [Array] args
+      # @param [String] filename
+      def run(args, filename)
+        options = parse_options(args, filename)
+        new(options).start
+      end
+    end
+
+    attr_reader :options
+
+    # @param [Hash] options
+    #   @see {Berkshelf::API::Application.run} for the list of valid options
+    def initialize(options = {})
+      @options = options
+    end
+
+    def start
+      Berkshelf::API::Application.run(options)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ Spork.prefork do
     config.filter_run focus: true
     config.run_all_when_everything_filtered = true
 
-    config.before(:all) { Berkshelf::API::Logging.init(location: nil) }
+    config.before(:suite) { Berkshelf::API::Logging.init(location: '/dev/null') }
 
     config.before do
       Celluloid.shutdown

--- a/spec/unit/berkshelf/api/application_spec.rb
+++ b/spec/unit/berkshelf/api/application_spec.rb
@@ -5,23 +5,5 @@ describe Berkshelf::API::Application do
     subject { described_class }
 
     its(:registry) { should be_a(Celluloid::Registry) }
-
-    describe "::parse_options" do
-      let(:arguments) { Array.new }
-      subject { described_class.parse_options(arguments) }
-
-      it "returns a Hash" do
-        expect(subject).to be_a(Hash)
-      end
-
-      context "given a value for -p" do
-        let(:arguments) { ["-p", "1984"] }
-
-        it "assigns the value as an integer to :port" do
-          expect(subject).to have_key(:port)
-          expect(subject[:port]).to eql(1984)
-        end
-      end
-    end
   end
 end

--- a/spec/unit/berkshelf/api/srv_ctl_spec.rb
+++ b/spec/unit/berkshelf/api/srv_ctl_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Berkshelf::API::SrvCtl do
+  describe "ClassMethods" do
+    describe "::parse_options" do
+      let(:args) { Array.new }
+      let(:filename) { "berks-api" }
+
+      subject { described_class.parse_options(args, filename) }
+
+      it "returns a hash" do
+        expect(subject).to be_a(Hash)
+      end
+
+      context "given -p" do
+        let(:args) { ["-p", "1234"] }
+
+        it "sets :pid_file to the given value" do
+          expect(subject[:port]).to eql(1234)
+        end
+      end
+
+      context "given -v" do
+        let(:args) { ["-v"] }
+
+        it "sets :log_level to INFO" do
+          expect(subject[:log_level]).to eql("INFO")
+        end
+      end
+
+      context "given -d" do
+        let(:args) { ["-d"] }
+
+        it "sets :log_level to DEBUG" do
+          expect(subject[:log_level]).to eql("DEBUG")
+        end
+      end
+
+      context "given -q" do
+        let(:args) { ["-q"] }
+
+        it "sets :log_location to /dev/null" do
+          expect(subject[:log_location]).to eql("/dev/null")
+        end
+      end
+
+      context "given -v and -d" do
+        let(:args) { ["-v", "-d"] }
+
+        it "sets :log_level to DEBUG" do
+          expect(subject[:log_level]).to eql("DEBUG")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Berkshelf::API::Application.run() now takes a set of options making it easier to start from another application

@andrewGarson check this out
