### PR TITLE
Add ability to configure which cache builders are started and how

### DIFF
--- a/berkshelf-api.gemspec
+++ b/berkshelf-api.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday'
   spec.add_dependency 'retryable', '~> 1.3.3'
   spec.add_dependency 'archive', '= 0.0.2'
+  spec.add_dependency 'buff-config', '~> 0.1'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'thor', '~> 0.18.0'

--- a/lib/berkshelf/api.rb
+++ b/lib/berkshelf/api.rb
@@ -17,6 +17,7 @@ module Berkshelf
     require_relative 'api/application'
     require_relative 'api/cache_builder'
     require_relative 'api/cache_manager'
+    require_relative 'api/config'
     require_relative 'api/dependency_cache'
     require_relative 'api/endpoint'
     require_relative 'api/rack_app'

--- a/lib/berkshelf/api/application.rb
+++ b/lib/berkshelf/api/application.rb
@@ -25,6 +25,10 @@ module Berkshelf::API
 
       def_delegators :registry, :[], :[]=
 
+      def config
+        @config ||= Berkshelf::API::Config.new
+      end
+
       def configure_logger(options = {})
         Logging.init(level: options[:log_level], location: options[:log_location])
       end

--- a/lib/berkshelf/api/cache_builder.rb
+++ b/lib/berkshelf/api/cache_builder.rb
@@ -33,7 +33,10 @@ module Berkshelf::API
       log.info "Cache Builder starting..."
       @worker_registry   = Celluloid::Registry.new
       @worker_supervisor = WorkerSupervisor.new(@worker_registry)
-      @worker_supervisor.supervise(CacheBuilder::Worker::Opscode, eager_build: true)
+
+      Application.config.endpoints.each do |endpoint|
+        @worker_supervisor.supervise(CacheBuilder::Worker[endpoint.type], endpoint.options)
+      end
     end
 
     def build

--- a/lib/berkshelf/api/cache_builder/worker.rb
+++ b/lib/berkshelf/api/cache_builder/worker.rb
@@ -2,6 +2,15 @@ module Berkshelf::API
   class CacheBuilder
     module Worker
       class Base
+        class << self
+          # @param [#to_s, nil] type
+          def worker_type(type = nil)
+            return @worker_type if @worker_type
+            @worker_type = type.to_s
+            Worker.register(@worker_type, self)
+          end
+        end
+
         INTERVAL = 5
 
         include Celluloid
@@ -87,6 +96,30 @@ module Berkshelf::API
           def clear_diff
             @diff = nil
           end
+      end
+
+      class << self
+        # @param [#to_s] name
+        #
+        # @return [Worker::Base]
+        def [](name)
+          types[name.to_s]
+        end
+
+        # @param [#to_s] name
+        # @param [Worker::Base] klass
+        def register(name, klass)
+          name = name.to_s
+          if types.has_key?(name)
+            raise RuntimeError, "worker already registered with the name '#{name}'"
+          end
+          types[name] = klass
+        end
+
+        # @return [Hash]
+        def types
+          @types ||= Hash.new
+        end
       end
     end
   end

--- a/lib/berkshelf/api/cache_builder/worker/chef_server.rb
+++ b/lib/berkshelf/api/cache_builder/worker/chef_server.rb
@@ -2,6 +2,8 @@ module Berkshelf::API
   class CacheBuilder
     module Worker
       class ChefServer < Worker::Base
+        worker_type "chef_server"
+
         finalizer :finalize_callback
 
         def initialize(options = {})

--- a/lib/berkshelf/api/cache_builder/worker/opscode.rb
+++ b/lib/berkshelf/api/cache_builder/worker/opscode.rb
@@ -2,6 +2,8 @@ module Berkshelf::API
   class CacheBuilder
     module Worker
       class Opscode < Worker::Base
+        worker_type "opscode"
+
         finalizer :finalize_callback
 
         def initialize(options = {})

--- a/lib/berkshelf/api/config.rb
+++ b/lib/berkshelf/api/config.rb
@@ -1,0 +1,18 @@
+require 'buff/config/json'
+
+module Berkshelf::API
+  class Config < Buff::Config::JSON
+    class << self
+      # @return [String]
+      def default_path
+        File.expand_path("~/.berkshelf/api-server/config.json")
+      end
+    end
+
+    attribute 'endpoints',
+      type: Array,
+      default: [
+        { type: "opscode", url: 'http://cookbooks.opscode.com/api/v1' }
+      ]
+  end
+end

--- a/lib/berkshelf/api/config.rb
+++ b/lib/berkshelf/api/config.rb
@@ -12,7 +12,12 @@ module Berkshelf::API
     attribute 'endpoints',
       type: Array,
       default: [
-        { type: "opscode", url: 'http://cookbooks.opscode.com/api/v1' }
+        {
+          type: "opscode",
+          options: {
+            url: 'http://cookbooks.opscode.com/api/v1'
+          }
+        }
       ]
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ Spork.prefork do
     config.filter_run focus: true
     config.run_all_when_everything_filtered = true
 
-    config.before(:suite) { Berkshelf::API::Logging.init(location: '/dev/null') }
+    config.before(:all) { Berkshelf::API::Logging.init(location: '/dev/null') }
 
     config.before do
       Celluloid.shutdown

--- a/spec/unit/berkshelf/api/cache_builder/worker/chef_server_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker/chef_server_spec.rb
@@ -1,5 +1,8 @@
 require 'spec_helper'
 
 describe Berkshelf::API::CacheBuilder::Worker::ChefServer do
-  pending
+  describe "ClassMethods" do
+    subject { described_class }
+    its(:worker_type) { should eql("chef_server") }
+  end
 end

--- a/spec/unit/berkshelf/api/cache_builder/worker/opscode_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker/opscode_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe Berkshelf::API::CacheBuilder::Worker::Opscode do
+  describe "ClassMethods" do
+    subject { described_class }
+    its(:worker_type) { should eql("opscode") }
+  end
+
   let(:cookbooks) { ["chicken", "tuna"] }
   let(:chicken_versions) { ["1.0", "2.0"] }
   let(:tuna_versions) { ["3.0.0", "3.0.1"] }

--- a/spec/unit/berkshelf/api/cache_builder/worker_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker_spec.rb
@@ -1,6 +1,43 @@
 require 'spec_helper'
 
+describe Berkshelf::API::CacheBuilder::Worker do
+  describe "ClassMethods" do
+    describe "::[]" do
+      it "returns the class of the registered worker" do
+        expect(described_class["opscode"]).to eql(Berkshelf::API::CacheBuilder::Worker::Opscode)
+      end
+    end
+
+    describe "::register" do
+      it "adds the item to the Hash of types" do
+        worker = double('new-worker')
+        described_class.register("rspec-2", worker)
+        expect(described_class.types["rspec-2"]).to eql(worker)
+      end
+    end
+
+    describe "::types" do
+      subject { described_class.types }
+
+      it "returns a Hash" do
+        expect(subject).to be_a(Hash)
+      end
+    end
+  end
+end
+
 describe Berkshelf::API::CacheBuilder::Worker::Base do
+  describe "ClassMethods" do
+    describe "::worker_type" do
+      let(:klass) { Class.new(described_class) }
+
+      it "registers the worker type and class to Worker.types" do
+        klass.worker_type("rspec")
+        expect(Berkshelf::API::CacheBuilder::Worker.types).to include("rspec")
+      end
+    end
+  end
+
   let(:cache_manager) { double(:diff => :chicken) }
   subject { described_class.new(eager_build: false) }
 

--- a/spec/unit/berkshelf/api/config_spec.rb
+++ b/spec/unit/berkshelf/api/config_spec.rb
@@ -18,7 +18,7 @@ describe Berkshelf::API::Config do
 
     it "has the Opscode community site as an endpoint" do
       expect(subject.endpoints.first.type).to eql("opscode")
-      expect(subject.endpoints.first.url).to eql("http://cookbooks.opscode.com/api/v1")
+      expect(subject.endpoints.first.options[:url]).to eql("http://cookbooks.opscode.com/api/v1")
     end
   end
 end

--- a/spec/unit/berkshelf/api/config_spec.rb
+++ b/spec/unit/berkshelf/api/config_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Berkshelf::API::Config do
+  describe "ClassMethods" do
+    describe "::default_path" do
+      it "returns a String" do
+        expect(described_class.default_path).to be_a(String)
+      end
+    end
+  end
+
+  describe "default config" do
+    subject { described_class.new }
+
+    it "has a endpoint configured" do
+      expect(subject.endpoints).to have(1).item
+    end
+
+    it "has the Opscode community site as an endpoint" do
+      expect(subject.endpoints.first.type).to eql("opscode")
+      expect(subject.endpoints.first.url).to eql("http://cookbooks.opscode.com/api/v1")
+    end
+  end
+end


### PR DESCRIPTION
This will add a basic configuration class and start cache builders based on endpoints defined in it. The default configuration will start just the Opscode community site worker.
