### PR TITLE
drop ruby 1.9.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0.0
 notifications:

--- a/berkshelf-api.gemspec
+++ b/berkshelf-api.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(spec|features)/})
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 1.9.2"
+  spec.required_ruby_version = ">= 1.9.3"
 
   spec.add_dependency 'ridley', '~> 1.2.3'
   spec.add_dependency 'celluloid', '~> 0.14.0'


### PR DESCRIPTION
1.9.2 is not an officially supported Ruby in Celluloid
