### PR TITLE
items added to the cache are now tagged with a location type

### DIFF
--- a/lib/berkshelf/api/cache_builder/worker.rb
+++ b/lib/berkshelf/api/cache_builder/worker.rb
@@ -76,7 +76,7 @@ module Berkshelf::API
           created_cookbooks.collect do |remote|
             [ remote, future(:metadata, remote) ]
           end.each do |remote, metadata|
-            cache_manager.add(remote.name, remote.version, metadata.value)
+            cache_manager.add(remote, metadata.value)
           end
 
           log.info "#{self} removing (#{deleted_cookbooks.length}) items..."

--- a/lib/berkshelf/api/cache_builder/worker/chef_server.rb
+++ b/lib/berkshelf/api/cache_builder/worker/chef_server.rb
@@ -17,7 +17,9 @@ module Berkshelf::API
         def cookbooks
           cookbook_versions = Array.new
           connection.cookbook.all.each do |cookbook, versions|
-            versions.each { |version| cookbook_versions << RemoteCookbook.new(cookbook, version) }
+            versions.each do |version|
+              cookbook_versions << RemoteCookbook.new(cookbook, version, self.class.worker_type)
+            end
           end
           cookbook_versions
         end

--- a/lib/berkshelf/api/cache_builder/worker/opscode.rb
+++ b/lib/berkshelf/api/cache_builder/worker/opscode.rb
@@ -19,7 +19,9 @@ module Berkshelf::API
           connection.cookbooks.collect do |cookbook|
             [ cookbook, connection.future(:versions, cookbook) ]
           end.each do |cookbook, versions|
-            versions.value.each { |version| cookbook_versions << RemoteCookbook.new(cookbook, version) }
+            versions.value.each do |version|
+              cookbook_versions << RemoteCookbook.new(cookbook, version, self.class.worker_type)
+            end
           end
 
           cookbook_versions

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -89,15 +89,15 @@ module Berkshelf::API
     # @param [Array<RemoteCookbook>] cookbooks
     #   An array of RemoteCookbooks representing all the cookbooks on the indexed site
     #
-    # @return [Array<(Array<RemoteCookbook>, Array<RemoteCookbook>)>]
+    # @return [Array<Array<RemoteCookbook>, Array<RemoteCookbook>>]
     #   A tuple of Arrays of RemoteCookbooks
     #   The first array contains items not in the cache
     #   The second array contains items in the cache, but not in the cookbooks parameter
     def diff(cookbooks)
-      known_cookbooks = cache.cookbooks
+      known_cookbooks   = cache.cookbooks
       created_cookbooks = cookbooks - known_cookbooks
       deleted_cookbooks = known_cookbooks - cookbooks
-      [created_cookbooks, deleted_cookbooks]
+      [ created_cookbooks, deleted_cookbooks ]
     end
 
     private

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -53,13 +53,12 @@ module Berkshelf::API
       every(SAVE_INTERVAL) { save }
     end
 
-    # @param [String] name
-    # @param [String] version
+    # @param [RemoteCookbook] cookbook
     # @param [Ridley::Chef::Cookbook::Metadata] metadata
     #
     # @return [Hash]
-    def add(name, version, metadata)
-      @cache.add(name, version, metadata)
+    def add(cookbook, metadata)
+      @cache.add(cookbook, metadata)
     end
 
     # Clear any items added to the cache

--- a/lib/berkshelf/api/dependency_cache.rb
+++ b/lib/berkshelf/api/dependency_cache.rb
@@ -40,16 +40,16 @@ module Berkshelf::API
       @cache = Hash[contents]
     end
 
-    # @param [String] name
-    # @param [String] version
+    # @param [RemoteCookbook] cookbook
     # @param [Ridley::Chef::Cookbook::Metadata] metadata
     #
     # @return [Hash]
-    def add(name, version, metadata)
-      @cache[name.to_s] ||= Hash.new
-      @cache[name.to_s][version.to_s] = {
+    def add(cookbook, metadata)
+      @cache[cookbook.name.to_s] ||= Hash.new
+      @cache[cookbook.name.to_s][cookbook.version.to_s] = {
         platforms: metadata.platforms,
-        dependencies: metadata.dependencies
+        dependencies: metadata.dependencies,
+        location_type: cookbook.location_type
       }
     end
 

--- a/lib/berkshelf/api/dependency_cache.rb
+++ b/lib/berkshelf/api/dependency_cache.rb
@@ -45,10 +45,12 @@ module Berkshelf::API
     #
     # @return [Hash]
     def add(cookbook, metadata)
+      platforms    = metadata.platforms || Hash.new
+      dependencies = metadata.dependencies || Hash.new
       @cache[cookbook.name.to_s] ||= Hash.new
       @cache[cookbook.name.to_s][cookbook.version.to_s] = {
-        platforms: metadata.platforms,
-        dependencies: metadata.dependencies,
+        platforms: platforms,
+        dependencies: dependencies,
         location_type: cookbook.location_type
       }
     end
@@ -91,7 +93,9 @@ module Berkshelf::API
     def cookbooks
       [].tap do |remote_cookbooks|
         @cache.each_pair do |name, versions|
-          versions.keys.each { |version| remote_cookbooks << RemoteCookbook.new(name, version) }
+          versions.each do |version, metadata|
+            remote_cookbooks << RemoteCookbook.new(name, version, metadata[:location_type])
+          end
         end
       end
     end

--- a/lib/berkshelf/api/remote_cookbook.rb
+++ b/lib/berkshelf/api/remote_cookbook.rb
@@ -1,3 +1,3 @@
 module Berkshelf::API
-  class RemoteCookbook < Struct.new(:name, :version); end
+  class RemoteCookbook < Struct.new(:name, :version, :location_type); end
 end

--- a/lib/berkshelf/api/site_connector/opscode.rb
+++ b/lib/berkshelf/api/site_connector/opscode.rb
@@ -89,15 +89,30 @@ module Berkshelf::API
       # @param [String] destination
       #   The directory to download the cookbook to
       #
-      # @return [String]
+      # @return [String, nil]
       def download(name, version, destination = Dir.mktmpdir)
         log.info "downloading #{name}(#{version})"
-        if cookbook = find(name, version)
-          archive = stream(cookbook[:file])
+        if uri = download_uri(name, version)
+          archive = stream(uri)
           Archive.extract(archive.path, destination)
         end
       ensure
         archive.unlink unless archive.nil?
+      end
+
+      # Return the location where a cookbook of the given name and version can be downloaded from
+      #
+      # @param [String] cookbook
+      #   The name of the cookbook
+      # @param [String] version
+      #   The version of the cookbook
+      #
+      # @return [String, nil]
+      def download_uri(name, version)
+        unless cookbook = find(name, version)
+          return nil
+        end
+        cookbook[:file]
       end
 
       # @param [String] cookbook

--- a/spec/unit/berkshelf/api/cache_builder/worker/chef_server_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker/chef_server_spec.rb
@@ -28,5 +28,11 @@ describe Berkshelf::API::CacheBuilder::Worker::ChefServer do
         expect(cookbook).to be_a(Berkshelf::API::RemoteCookbook)
       end
     end
+
+    it "each RemoteCookbook is tagged with a location_type matching the worker_type of the builder" do
+      subject.cookbooks.each do |cookbook|
+        expect(cookbook.location_type).to eql(described_class.worker_type)
+      end
+    end
   end
 end

--- a/spec/unit/berkshelf/api/cache_builder/worker/opscode_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker/opscode_spec.rb
@@ -23,10 +23,10 @@ describe Berkshelf::API::CacheBuilder::Worker::Opscode do
   describe "#cookbooks" do
     it "returns an array of RemoteCookbooks described by the server" do
       expected_value = [
-        Berkshelf::API::RemoteCookbook.new("chicken", "1.0"),
-        Berkshelf::API::RemoteCookbook.new("chicken", "2.0"),
-        Berkshelf::API::RemoteCookbook.new("tuna", "3.0.0"),
-        Berkshelf::API::RemoteCookbook.new("tuna", "3.0.1"),
+        Berkshelf::API::RemoteCookbook.new("chicken", "1.0", described_class.worker_type),
+        Berkshelf::API::RemoteCookbook.new("chicken", "2.0", described_class.worker_type),
+        Berkshelf::API::RemoteCookbook.new("tuna", "3.0.0", described_class.worker_type),
+        Berkshelf::API::RemoteCookbook.new("tuna", "3.0.1", described_class.worker_type)
       ]
 
       connection.should_receive(:future).with(:versions, "chicken").and_return(double(value: chicken_versions))

--- a/spec/unit/berkshelf/api/dependency_cache_spec.rb
+++ b/spec/unit/berkshelf/api/dependency_cache_spec.rb
@@ -79,10 +79,11 @@ describe Berkshelf::API::DependencyCache do
   end
 
   describe "#add" do
+    let(:cookbook) { Berkshelf::API::RemoteCookbook.new("ruby", "1.2.3", "opscode") }
     before { subject.clear }
 
     it "adds items to the cache" do
-      subject.add("ruby", "1.2.3", double(platforms: nil, dependencies: nil))
+      subject.add(cookbook, double(platforms: nil, dependencies: nil))
       expect(subject.to_hash).to have(1).item
     end
   end
@@ -97,7 +98,8 @@ describe Berkshelf::API::DependencyCache do
   end
 
   describe "#clear" do
-    before { subject.add("ruby", "1.2.3", double(platforms: nil, dependencies: nil)) }
+    let(:cookbook) { Berkshelf::API::RemoteCookbook.new("ruby", "1.2.3", "opscode") }
+    before { subject.add(cookbook, double(platforms: nil, dependencies: nil)) }
 
     it "empties items added to the cache" do
       subject.clear


### PR DESCRIPTION
the location type is used to let the client know how to retrieve the item

_note:_ more data will probably be required for the chef_server location type. This will come in a future pull request.
