### PR TITLE
Only load RESTGateway when required

### DIFF
--- a/lib/berkshelf/api.rb
+++ b/lib/berkshelf/api.rb
@@ -9,6 +9,7 @@ module Berkshelf
     require_relative 'api/errors'
     require_relative 'api/logging'
     require_relative 'api/mixin'
+    require_relative 'api/generic_server'
 
     require_relative 'api/application'
     require_relative 'api/cache_builder'

--- a/lib/berkshelf/api.rb
+++ b/lib/berkshelf/api.rb
@@ -18,7 +18,6 @@ module Berkshelf
     require_relative 'api/endpoint'
     require_relative 'api/rack_app'
     require_relative 'api/remote_cookbook'
-    require_relative 'api/rest_gateway'
     require_relative 'api/site_connector'
     require_relative 'api/srv_ctl'
   end

--- a/lib/berkshelf/api/application.rb
+++ b/lib/berkshelf/api/application.rb
@@ -8,11 +8,19 @@ end
 
 module Berkshelf::API
   class ApplicationSupervisor < Celluloid::SupervisionGroup
+    # @option options [Boolean] :disable_http (false)
+    #   run the application without the rest gateway
     def initialize(registry, options = {})
       super(registry)
+      options = { disable_http: false }.merge(options)
+
       supervise_as(:cache_manager, Berkshelf::API::CacheManager)
       supervise_as(:cache_builder, Berkshelf::API::CacheBuilder)
-      supervise_as(:rest_gateway, Berkshelf::API::RESTGateway, options)
+
+      unless options[:disable_http]
+        require_relative 'rest_gateway'
+        supervise_as(:rest_gateway, Berkshelf::API::RESTGateway, options)
+      end
     end
   end
 
@@ -31,6 +39,13 @@ module Berkshelf::API
         end
       end
 
+      # @option options [String, Fixnum] :log_location (STDOUT)
+      # @option options [String, nil] :log_level ("INFO")
+      #   - "DEBUG
+      #   - "INFO"
+      #   - "WARN"
+      #   - "ERROR"
+      #   - "FATAL"
       def configure_logger(options = {})
         Logging.init(level: options[:log_level], location: options[:log_location])
       end
@@ -53,6 +68,9 @@ module Berkshelf::API
       end
 
       # Run the application in the foreground (sleep on main thread)
+      #
+      # @option options [Boolean] :disable_http (false)
+      #   run the application without the rest gateway
       def run(options = {})
         loop do
           supervisor = run!(options)
@@ -65,6 +83,10 @@ module Berkshelf::API
         end
       end
 
+      # Run the application in the background
+      #
+      # @option options [Boolean] :disable_http (false)
+      #   run the application without the rest gateway
       def run!(options = {})
         configure_logger(options)
         @instance = ApplicationSupervisor.new(registry, options)

--- a/lib/berkshelf/api/cache_builder.rb
+++ b/lib/berkshelf/api/cache_builder.rb
@@ -4,19 +4,10 @@ module Berkshelf::API
 
     class WorkerSupervisor < Celluloid::SupervisionGroup; end
 
-    class << self
-      # Start the cache builder and add it to the application's registry.
-      #
-      # @note you probably do not want to manually start the cache manager unless you
-      #   are testing the application. Start the entire application with {Berkshelf::API::Application.run}
-      def start
-        instance.async(:build)
-      end
-    end
-
-    include Celluloid
+    include Berkshelf::API::GenericServer
     include Berkshelf::API::Logging
 
+    server_name :cache_builder
     finalizer :finalize_callback
 
     def initialize

--- a/lib/berkshelf/api/cache_builder.rb
+++ b/lib/berkshelf/api/cache_builder.rb
@@ -5,16 +5,6 @@ module Berkshelf::API
     class WorkerSupervisor < Celluloid::SupervisionGroup; end
 
     class << self
-      # @raise [Celluloid::DeadActorError] if Cache Builder has not been started
-      #
-      # @return [Celluloid::Actor(Berkshelf::API::CacheBuilder)]
-      def instance
-        unless Berkshelf::API::Application[:cache_builder] && Berkshelf::API::Application[:cache_builder].alive?
-          raise NotStartedError, "cache builder not running"
-        end
-        Berkshelf::API::Application[:cache_builder]
-      end
-
       # Start the cache builder and add it to the application's registry.
       #
       # @note you probably do not want to manually start the cache manager unless you

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -8,16 +8,6 @@ module Berkshelf::API
         @cache_file ||= File.expand_path("~/.berkshelf/api-server/cerch")
       end
 
-      # @raise [Celluloid::DeadActorError] if Bootstrap Manager has not been started
-      #
-      # @return [Celluloid::Actor(Berkshelf::API::CacheManager)]
-      def instance
-        unless Berkshelf::API::Application[:cache_manager] && Berkshelf::API::Application[:cache_manager].alive?
-          raise NotStartedError, "cache manager not running"
-        end
-        Berkshelf::API::Application[:cache_manager]
-      end
-
       # Start the cache manager and add it to the application's registry.
       #
       # @note you probably do not want to manually start the cache manager unless you

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -21,9 +21,9 @@ module Berkshelf::API
       # @note you probably don't want to manually stop the cache manager unless you are testing
       #   the application. Stop the entire application with {Berkshelf::API::Application.shutdown}
       def stop
-        instance.terminate
-      rescue NotStartedError
-        nil
+        unless actor = Berkshelf::API::Application[:cache_manager]
+          actor.terminate
+        end
       end
     end
 

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -7,31 +7,14 @@ module Berkshelf::API
       def cache_file
         @cache_file ||= File.expand_path("~/.berkshelf/api-server/cerch")
       end
-
-      # Start the cache manager and add it to the application's registry.
-      #
-      # @note you probably do not want to manually start the cache manager unless you
-      #   are testing the application. Start the entire application with {Berkshelf::API::Application.run}
-      def start
-        Berkshelf::API::Application[:cache_manager] = new
-      end
-
-      # Stop the cache manager if it's running.
-      #
-      # @note you probably don't want to manually stop the cache manager unless you are testing
-      #   the application. Stop the entire application with {Berkshelf::API::Application.shutdown}
-      def stop
-        unless actor = Berkshelf::API::Application[:cache_manager]
-          actor.terminate
-        end
-      end
     end
 
-    include Celluloid
+    include Berkshelf::API::GenericServer
     include Berkshelf::API::Logging
 
     SAVE_INTERVAL = 30.0
 
+    server_name :cache_manager
     finalizer :finalize_callback
 
     attr_reader :cache

--- a/lib/berkshelf/api/generic_server.rb
+++ b/lib/berkshelf/api/generic_server.rb
@@ -1,0 +1,35 @@
+module Berkshelf::API
+  module GenericServer
+    class << self
+      def included(base)
+        base.send(:include, Celluloid)
+        base.send(:extend, ClassMethods)
+      end
+    end
+
+    module ClassMethods
+      def server_name(name = nil)
+        return @server_name if name.nil?
+        @server_name = name
+      end
+
+      # Start the cache manager and add it to the application's registry.
+      #
+      # @note you probably do not want to manually start the cache manager unless you
+      #   are testing the application. Start the entire application with {Berkshelf::API::Application.run}
+      def start(*args)
+        Berkshelf::API::Application[server_name] = new(*args)
+      end
+
+      # Stop the cache manager if it's running.
+      #
+      # @note you probably don't want to manually stop the cache manager unless you are testing
+      #   the application. Stop the entire application with {Berkshelf::API::Application.shutdown}
+      def stop
+        unless actor = Berkshelf::API::Application[server_name]
+          actor.terminate
+        end
+      end
+    end
+  end
+end

--- a/lib/berkshelf/api/mixin/services.rb
+++ b/lib/berkshelf/api/mixin/services.rb
@@ -19,6 +19,10 @@ module Berkshelf::API
         def cache_manager
           Berkshelf::API::CacheManager.instance
         end
+
+        def rest_gateway
+          Berkshelf::API::Application[:rest_gateway]
+        end
       end
     end
   end

--- a/lib/berkshelf/api/mixin/services.rb
+++ b/lib/berkshelf/api/mixin/services.rb
@@ -13,16 +13,28 @@ module Berkshelf::API
       end
 
       module ClassMethods
-        # @raise [Celluloid::DeadActorError] if the bootstrap manager has not been started
+        # @raise [Berkshelf::API::NotStartedError] if the cache manager has not been started
         #
-        # @return [Celluloid::Actor(Berkshelf::API::CacheManager)]
+        # @return [Berkshelf::API::CacheManager]
         def cache_manager
-          Berkshelf::API::CacheManager.instance
+          app_actor(:cache_manager)
         end
 
+        # @raise [Berkshelf::API::NotStartedError] if the rest gateway has not been started
+        #
+        # @return [Berkshelf::API::RESTGateway]
         def rest_gateway
-          Berkshelf::API::Application[:rest_gateway]
+          app_actor(:rest_gateway)
         end
+
+        private
+
+          def app_actor(id)
+            unless Application[id] && Application[id].alive?
+              raise NotStartedError, "cache manager not running"
+            end
+            Application[id]
+          end
       end
     end
   end

--- a/lib/berkshelf/api/mixin/services.rb
+++ b/lib/berkshelf/api/mixin/services.rb
@@ -15,6 +15,13 @@ module Berkshelf::API
       module ClassMethods
         # @raise [Berkshelf::API::NotStartedError] if the cache manager has not been started
         #
+        # @return [Berkshelf::API::CacheBuilder]
+        def cache_builder
+          app_actor(:cache_builder)
+        end
+
+        # @raise [Berkshelf::API::NotStartedError] if the cache manager has not been started
+        #
         # @return [Berkshelf::API::CacheManager]
         def cache_manager
           app_actor(:cache_manager)
@@ -31,7 +38,7 @@ module Berkshelf::API
 
           def app_actor(id)
             unless Application[id] && Application[id].alive?
-              raise NotStartedError, "cache manager not running"
+              raise NotStartedError, "#{id} not running"
             end
             Application[id]
           end

--- a/lib/berkshelf/api/rest_gateway.rb
+++ b/lib/berkshelf/api/rest_gateway.rb
@@ -3,7 +3,7 @@ require 'reel'
 module Berkshelf::API
   class RESTGateway < Reel::Server
     extend Forwardable
-    include Celluloid
+    include Berkshelf::API::GenericServer
     include Berkshelf::API::Logging
 
     DEFAULT_OPTIONS = {
@@ -22,6 +22,7 @@ module Berkshelf::API
 
     def_delegator :handler, :rack_app
 
+    server_name :rest_gateway
     finalizer :finalize_callback
 
     # @option options [String] :host ('0.0.0.0')

--- a/spec/unit/berkshelf/api/application_spec.rb
+++ b/spec/unit/berkshelf/api/application_spec.rb
@@ -5,5 +5,20 @@ describe Berkshelf::API::Application do
     subject { described_class }
 
     its(:registry) { should be_a(Celluloid::Registry) }
+
+    describe "::run!" do
+      include Berkshelf::API::Mixin::Services
+
+      let(:options) { { log_location: '/dev/null' } }
+      subject(:run) { described_class.run!(options) }
+
+      context "when given true for :disable_http" do
+        it "does not start the REST Gateway" do
+          options[:disable_http] = true
+          run
+          expect(rest_gateway).to be_nil
+        end
+      end
+    end
   end
 end

--- a/spec/unit/berkshelf/api/application_spec.rb
+++ b/spec/unit/berkshelf/api/application_spec.rb
@@ -16,7 +16,7 @@ describe Berkshelf::API::Application do
         it "does not start the REST Gateway" do
           options[:disable_http] = true
           run
-          expect(rest_gateway).to be_nil
+          expect { rest_gateway }.to raise_error(Berkshelf::API::NotStartedError)
         end
       end
     end

--- a/spec/unit/berkshelf/api/cache_manager_spec.rb
+++ b/spec/unit/berkshelf/api/cache_manager_spec.rb
@@ -29,25 +29,6 @@ describe Berkshelf::API::CacheManager do
       end
     end
 
-    describe "::instance" do
-      subject { described_class.instance }
-      context "when the cache manager is started" do
-        before { described_class.start }
-
-        it "returns the instance of cache manager" do
-          expect(subject).to be_a(described_class)
-        end
-      end
-
-      context "when the cache manager is not started" do
-        before { Berkshelf::API::Application.stub(:[]).with(:cache_manager).and_return(nil) }
-
-        it "raises a NotStartedError" do
-          expect { subject }.to raise_error(Berkshelf::API::NotStartedError)
-        end
-      end
-    end
-
     describe "::start" do
       it "starts and registers a cache manager it with the application" do
         described_class.start

--- a/spec/unit/berkshelf/api/mixin/services_spec.rb
+++ b/spec/unit/berkshelf/api/mixin/services_spec.rb
@@ -1,8 +1,29 @@
 require 'spec_helper'
+require 'berkshelf/api/rest_gateway'
 
 describe Berkshelf::API::Mixin::Services do
   let(:includer) do
     Class.new { include Berkshelf::API::Mixin::Services }.new
+  end
+
+  describe "#cache_builder" do
+    subject { includer.cache_builder }
+
+    context "when the CacheBuilder is running" do
+      before { Berkshelf::API::CacheBuilder.start }
+
+      it "returns the running instance of CacheBuilder" do
+        expect(subject).to be_a(Berkshelf::API::CacheBuilder)
+      end
+    end
+
+    context "when the CacheBuilder is not running" do
+      before { Berkshelf::API::CacheBuilder.stop }
+
+      it "raises a NotStartedError" do
+        expect { subject }.to raise_error(Berkshelf::API::NotStartedError)
+      end
+    end
   end
 
   describe "#cache_manager" do
@@ -18,6 +39,26 @@ describe Berkshelf::API::Mixin::Services do
 
     context "when the CacheManager is not running" do
       before { Berkshelf::API::CacheManager.stop }
+
+      it "raises a NotStartedError" do
+        expect { subject }.to raise_error(Berkshelf::API::NotStartedError)
+      end
+    end
+  end
+
+  describe "#rest_gateway" do
+    subject { includer.rest_gateway }
+
+    context "when the RESTGateway is running" do
+      before { Berkshelf::API::RESTGateway.start }
+
+      it "returns the running instance of RESTGateway" do
+        expect(subject).to be_a(Berkshelf::API::RESTGateway)
+      end
+    end
+
+    context "when the RESTGateway is not running" do
+      before { Berkshelf::API::RESTGateway.stop }
 
       it "raises a NotStartedError" do
         expect { subject }.to raise_error(Berkshelf::API::NotStartedError)

--- a/spec/unit/berkshelf/api/rest_gateway_spec.rb
+++ b/spec/unit/berkshelf/api/rest_gateway_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'berkshelf/api/rest_gateway'
 
 describe Berkshelf::API::RESTGateway do
   describe "ClassMethods" do


### PR DESCRIPTION
This will allow us to disable the RESTGateway when running the Berkshelf-API server within another Ruby process. Useful for running the API server within Berkshelf itself.
