### PR TITLE
cache builder will now schedule builds for workers

### DIFF
--- a/lib/berkshelf/api/cache_builder/worker.rb
+++ b/lib/berkshelf/api/cache_builder/worker.rb
@@ -11,20 +11,13 @@ module Berkshelf::API
           end
         end
 
-        INTERVAL = 5
-
         include Celluloid
         include Berkshelf::API::Logging
         include Berkshelf::API::Mixin::Services
 
         attr_reader :options
 
-        # @option options [Boolean] :eager_build (true)
-        #   immediately begin building the cache
-        def initialize(options = {})
-          @options = { eager_build: true }.merge(options)
-          async(:build) if @options[:eager_build]
-        end
+        def initialize(options = {}); end
 
         # @abstract
         #
@@ -44,24 +37,17 @@ module Berkshelf::API
         end
 
         def build
-          return if @building
-
           log.info "#{self} building..."
-
-          loop do
-            @building = true
-
-            log.info "#{self} determining if the cache is stale..."
-            if stale?
-              log.info "#{self} cache is stale."
-              update_cache
-            else
-              log.info "#{self} cache is up to date."
-            end
-
-            sleep INTERVAL
-            clear_diff
+          log.info "#{self} determining if the cache is stale..."
+          if stale?
+            log.info "#{self} cache is stale."
+            update_cache
+          else
+            log.info "#{self} cache is up to date."
           end
+
+          log.info "clearing diff"
+          clear_diff
         end
 
         # @return [Array<Array<RemoteCookbook>, Array<RemoteCookbook>>]

--- a/lib/berkshelf/api/srv_ctl.rb
+++ b/lib/berkshelf/api/srv_ctl.rb
@@ -50,7 +50,8 @@ module Berkshelf
       # @param [Hash] options
       #   @see {Berkshelf::API::Application.run} for the list of valid options
       def initialize(options = {})
-        @options = options
+        @options               = options
+        @options[:eager_build] = true
       end
 
       def start

--- a/spec/unit/berkshelf/api/cache_builder/worker/chef_server_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker/chef_server_spec.rb
@@ -8,7 +8,7 @@ describe Berkshelf::API::CacheBuilder::Worker::ChefServer do
 
   subject do
     described_class.new(url: "http://localhost:8889", client_name: "reset",
-      client_key: fixtures_path.join("reset.pem"), eager_build: false)
+      client_key: fixtures_path.join("reset.pem"))
   end
 
   describe "#cookbooks" do
@@ -33,6 +33,27 @@ describe Berkshelf::API::CacheBuilder::Worker::ChefServer do
       subject.cookbooks.each do |cookbook|
         expect(cookbook.location_type).to eql(described_class.worker_type)
       end
+    end
+  end
+
+  describe "#build" do
+    before do
+      Berkshelf::API::CacheManager.start
+      chef_cookbook("ruby", "1.0.0")
+      chef_cookbook("ruby", "2.0.0")
+      chef_cookbook("elixir", "3.0.0")
+      chef_cookbook("elixir", "3.0.1")
+    end
+
+    let(:cache) { Berkshelf::API::CacheManager.instance.cache }
+
+    it "adds each item to the cache" do
+      subject.build
+      expect(cache).to have_cookbook("ruby", "1.0.0")
+      expect(cache).to have_cookbook("ruby", "2.0.0")
+      expect(cache).to have_cookbook("elixir", "3.0.0")
+      expect(cache).to have_cookbook("elixir", "3.0.1")
+      expect(cache.cookbooks).to have(4).items
     end
   end
 end

--- a/spec/unit/berkshelf/api/cache_builder/worker_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker_spec.rb
@@ -39,7 +39,7 @@ describe Berkshelf::API::CacheBuilder::Worker::Base do
   end
 
   let(:cache_manager) { double(:diff => :chicken) }
-  subject { described_class.new(eager_build: false) }
+  subject { described_class.new }
 
   describe "#diff" do
     it "should delegate to the cache_manager to calculate the diff" do

--- a/spec/unit/berkshelf/api/cache_builder_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder_spec.rb
@@ -1,5 +1,37 @@
 require 'spec_helper'
 
 describe Berkshelf::API::CacheBuilder do
-  pending
+  let(:instance) { described_class.new }
+
+  describe "#build" do
+    subject(:build) { instance.build }
+    let(:workers) { [ double('worker') ] }
+    let(:future) { double('future', value: nil) }
+
+    before { instance.stub(workers: workers) }
+
+    it "sends a #build message to each worker" do
+      workers.each { |worker| worker.should_receive(:future).with(:build).and_return(future) }
+      build
+    end
+  end
+
+  describe "#workers" do
+    subject(:workers) { instance.workers }
+
+    it "returns an array of workers" do
+      expect(workers).to be_a(Array)
+      workers.each do |worker|
+        expect(worker).to be_a(described_class::Worker::Base)
+      end
+    end
+
+    it "has one worker started by default" do
+      expect(workers).to have(1).item
+    end
+
+    it "has an opscode worker started by default" do
+      expect(workers.first).to be_a(described_class::Worker::Opscode)
+    end
+  end
 end


### PR DESCRIPTION
These changes are necessary for testing purposes in Berkshelf
- CacheBuilder#build will now perform one cache build
- CacheBuilder#build_loop will perform a cache build on each worker in a loop and sleep for the given interval
