### PR TITLE
Crashed cache builder workers do not automatically rebuild

### DIFF
--- a/lib/berkshelf/api/cache_builder.rb
+++ b/lib/berkshelf/api/cache_builder.rb
@@ -27,7 +27,13 @@ module Berkshelf::API
     #
     # @return [Array]
     def build
-      workers.collect { |actor| actor.future(:build) }.map(&:value)
+      workers.collect { |actor| actor.future(:build) }.map do |f|
+        begin
+          f.value
+        rescue => ex
+          log.error ex
+        end
+      end
     end
 
     # Issue a build command to all workers at the scheduled interval

--- a/lib/berkshelf/api/cache_builder.rb
+++ b/lib/berkshelf/api/cache_builder.rb
@@ -19,7 +19,8 @@ module Berkshelf::API
       @building          = false
 
       Application.config.endpoints.each do |endpoint|
-        @worker_supervisor.supervise(CacheBuilder::Worker[endpoint.type], endpoint.options)
+        endpoint_options = endpoint.options.to_hash.deep_symbolize_keys
+        @worker_supervisor.supervise(CacheBuilder::Worker[endpoint.type], endpoint_options)
       end
     end
 
@@ -30,9 +31,7 @@ module Berkshelf::API
       workers.collect { |actor| actor.future(:build) }.map do |f|
         begin
           f.value
-        rescue => ex
-          log.error ex
-        end
+        rescue; end
       end
     end
 

--- a/lib/berkshelf/api/cache_builder/worker/opscode.rb
+++ b/lib/berkshelf/api/cache_builder/worker/opscode.rb
@@ -7,7 +7,7 @@ module Berkshelf::API
         finalizer :finalize_callback
 
         def initialize(options = {})
-          @connection = Berkshelf::API::SiteConnector::Opscode.pool_link(size: 25)
+          @connection = Berkshelf::API::SiteConnector::Opscode.pool_link(size: 25, args: [ options ])
           super
         end
 

--- a/lib/berkshelf/api/config.rb
+++ b/lib/berkshelf/api/config.rb
@@ -5,7 +5,8 @@ module Berkshelf::API
     class << self
       # @return [String]
       def default_path
-        File.expand_path("~/.berkshelf/api-server/config.json")
+        home_path = ENV['BERKSHELF_API_PATH'] || "~/.berkshelf/api-server"
+        File.expand_path(File.join(home_path, "config.json"))
       end
     end
 

--- a/lib/berkshelf/api/site_connector/opscode.rb
+++ b/lib/berkshelf/api/site_connector/opscode.rb
@@ -39,11 +39,11 @@ module Berkshelf::API
       # @param [Faraday::Connection] connection
       #   Optional parameter for setting the connection object
       #   This should only be set manually for testing
-      def initialize(uri = V1_API, options = {})
-        options  = { retries: 5, retry_interval: 0.5 }.merge(options)
-        @api_uri = uri
+      def initialize(options = {})
+        options  = { url: V1_API, retries: 5, retry_interval: 0.5 }.merge(options)
+        @api_uri = options[:url]
 
-        @connection = Faraday.new(uri) do |c|
+        @connection = Faraday.new(@api_uri) do |c|
           c.response :parse_json
           c.use Faraday::Adapter::NetHttp
         end


### PR DESCRIPTION
If a cache builder worker crashes it will be restarted by the cache builder, but it will not automatically begin to build it's cache again.
