### PR TITLE
call our parents shutdown function in RESTGateway

### DIFF
--- a/lib/berkshelf/api/rest_gateway.rb
+++ b/lib/berkshelf/api/rest_gateway.rb
@@ -56,6 +56,7 @@ module Berkshelf::API
       attr_reader :handler
 
       def finalize_callback
+        shutdown
         pool.terminate if pool && pool.alive?
       end
   end


### PR DESCRIPTION
This was necessary to ensure the socket we opened was not left open. It's not the pool which is keeping it open.

@sethvargo @ivey
