### PR TITLE
Don't return data until the cache has been warmed

### DIFF
--- a/lib/berkshelf/api/cache_builder.rb
+++ b/lib/berkshelf/api/cache_builder.rb
@@ -8,6 +8,7 @@ module Berkshelf::API
 
     include Berkshelf::API::GenericServer
     include Berkshelf::API::Logging
+    include Berkshelf::API::Mixin::Services
 
     server_name :cache_builder
     finalizer :finalize_callback
@@ -33,6 +34,7 @@ module Berkshelf::API
           f.value
         rescue; end
       end
+      cache_manager.set_warmed
     end
 
     # Issue a build command to all workers at the scheduled interval

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -9,6 +9,9 @@ module Berkshelf::API
 
     include Berkshelf::API::GenericServer
     include Berkshelf::API::Logging
+    
+    extend Forwardable
+    def_delegators :@cache, :warmed?, :set_warmed
 
     SAVE_INTERVAL = 30.0
 
@@ -73,7 +76,7 @@ module Berkshelf::API
     # @param [Array<RemoteCookbook>] cookbooks
     #   An array of RemoteCookbooks representing all the cookbooks on the indexed site
     #
-    # @return [Array<Array<RemoteCookbook>, Array<RemoteCookbook>>]
+    # @return [Array(Array<RemoteCookbook>, Array<RemoteCookbook>)]
     #   A tuple of Arrays of RemoteCookbooks
     #   The first array contains items not in the cache
     #   The second array contains items in the cache, but not in the cookbooks parameter

--- a/lib/berkshelf/api/dependency_cache.rb
+++ b/lib/berkshelf/api/dependency_cache.rb
@@ -12,6 +12,9 @@ module Berkshelf::API
   #     }
   #   }
   class DependencyCache
+
+    include Berkshelf::API::Logging
+
     class << self
       # Read an archived cache and re-instantiate it
       #
@@ -35,10 +38,11 @@ module Berkshelf::API
     extend Forwardable
     def_delegators :@cache, :[], :[]=
 
-    # @param [Hash] contents
-    def initialize(contents = {})
-      @cache = Hash[contents]
-    end
+      # @param [Hash] contents
+      def initialize(contents = {})
+        @warmed = false
+        @cache = Hash[contents]
+      end
 
     # @param [RemoteCookbook] cookbook
     # @param [Ridley::Chef::Cookbook::Metadata] metadata
@@ -118,6 +122,14 @@ module Berkshelf::API
     def save(path)
       FileUtils.mkdir_p(File.dirname(path))
       File.open(path, 'w+') { |f| f.write(self.to_json) }
+    end
+
+    def warmed?
+      @warmed
+    end
+
+    def set_warmed
+      @warmed = true
     end
   end
 end

--- a/lib/berkshelf/api/dependency_cache.rb
+++ b/lib/berkshelf/api/dependency_cache.rb
@@ -38,11 +38,11 @@ module Berkshelf::API
     extend Forwardable
     def_delegators :@cache, :[], :[]=
 
-      # @param [Hash] contents
-      def initialize(contents = {})
-        @warmed = false
-        @cache = Hash[contents]
-      end
+    # @param [Hash] contents
+    def initialize(contents = {})
+      @warmed = false
+      @cache = Hash[contents]
+    end
 
     # @param [RemoteCookbook] cookbook
     # @param [Ridley::Chef::Cookbook::Metadata] metadata

--- a/lib/berkshelf/api/endpoint/v1.rb
+++ b/lib/berkshelf/api/endpoint/v1.rb
@@ -12,7 +12,12 @@ module Berkshelf::API
 
       desc "list all known cookbooks"
       get 'universe' do
-        cache_manager.cache
+        if cache_manager.warmed?
+          cache_manager.cache
+        else
+          header "Retry-After", 600
+          status 503
+        end
       end
     end
   end

--- a/spec/unit/berkshelf/api/cache_builder_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Berkshelf::API::CacheBuilder do
+
+  before { Berkshelf::API::CacheManager.start }
   let(:instance) { described_class.new }
 
   describe "#build" do

--- a/spec/unit/berkshelf/api/endpoint/v1_spec.rb
+++ b/spec/unit/berkshelf/api/endpoint/v1_spec.rb
@@ -8,11 +8,24 @@ describe Berkshelf::API::Endpoint::V1 do
   let(:app) { described_class.new }
 
   describe "GET /universe" do
-    before  { get '/universe' }
-    subject { last_response }
-    let(:app_cache) { cache_manager.cache }
+    context "the cache has been warmed" do
+      before { cache_manager.set_warmed; get '/universe' }
 
-    its(:status) { should be(200) }
-    its(:body) { should eq(app_cache.to_json) }
+      subject { last_response }
+      let(:app_cache) { cache_manager.cache }
+
+      its(:status) { should be(200) }
+      its(:body) { should eq(app_cache.to_json) }
+    end
+
+    context "the cache is still warming" do
+      before { get '/universe' }
+
+      subject { last_response }
+      let(:app_cache) { cache_manager.cache }
+
+      its(:status) { should be(503) }
+      its(:headers) { should have_key("Retry-After") }
+    end
   end
 end


### PR DESCRIPTION
Adds a warmed flag to the cache and checks it before returning from /universe. The flag is set after each build_loop for all builders
