### PR TITLE
build interval ignored in favor of constant default

### DIFF
--- a/lib/berkshelf/api/cache_builder.rb
+++ b/lib/berkshelf/api/cache_builder.rb
@@ -46,7 +46,7 @@ module Berkshelf::API
       loop do
         @building = true
         build
-        sleep BUILD_INTERVAL
+        sleep interval
       end
     end
 


### PR DESCRIPTION
# build_loop on Berkshelf::API::CacheBuilder accepts an interval parameter that is defaulted to BUILD_INTERVAL and then does a

```
sleep BUILD_INTERVAL
```

instead of
    sleep interval
