### PR TITLE
call CacheBuilder#build when starting rspec server for first time

### DIFF
--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -9,7 +9,7 @@ module Berkshelf::API
 
     include Berkshelf::API::GenericServer
     include Berkshelf::API::Logging
-    
+
     extend Forwardable
     def_delegators :@cache, :warmed?, :set_warmed
 

--- a/lib/berkshelf/api/rspec/server.rb
+++ b/lib/berkshelf/api/rspec/server.rb
@@ -18,7 +18,10 @@ module Berkshelf::API::RSpec
       def start(options = {})
         options = options.reverse_merge(port: 26210, log_location: "/dev/null", endpoints: [])
         Berkshelf::API::Application.config.endpoints = options[:endpoints]
-        Berkshelf::API::Application.run!(options) unless running?
+        unless running?
+          Berkshelf::API::Application.run!(options)
+          cache_builder.build
+        end
       end
 
       def stop


### PR DESCRIPTION
this will stop tests from throwing 503 errors

@ivey @andrewGarson 
