### PR TITLE
RemoteCookbooks are compared using set notation, this requires you to

### DIFF
--- a/lib/berkshelf/api/remote_cookbook.rb
+++ b/lib/berkshelf/api/remote_cookbook.rb
@@ -1,12 +1,11 @@
 module Berkshelf::API
-  class RemoteCookbook < Struct.new(:name, :version, :location_type, :location_path); end
+  class RemoteCookbook < Struct.new(:name, :version, :location_type, :location_path)
+    def hash
+      "#{name}|#{version}".hash
+    end
 
-  def hash
-    "#{name}|#{version}".hash
+    def eql?(other)
+      self.hash == other.hash
+    end
   end
-
-  def eql?(other)
-    self.hash == other.hash
-  end
-
 end

--- a/lib/berkshelf/api/remote_cookbook.rb
+++ b/lib/berkshelf/api/remote_cookbook.rb
@@ -1,3 +1,12 @@
 module Berkshelf::API
   class RemoteCookbook < Struct.new(:name, :version, :location_type, :location_path); end
+
+  def hash
+    "#{name}|#{version}".hash
+  end
+
+  def eql?(other)
+    self.hash == other.hash
+  end
+
 end


### PR DESCRIPTION
implement #eql? and #hash for appropriate behavior

Without this, if you save a full cache then restart the server, it will
rebuild the cache as if it were empty (removing all existing items on
the first pass through).
