### PR TITLE
Refactor cache builder

### DIFF
--- a/lib/berkshelf/api/cache_builder.rb
+++ b/lib/berkshelf/api/cache_builder.rb
@@ -25,16 +25,8 @@ module Berkshelf::API
       end
     end
 
-    # Issue a single build command to all workers
-    #
-    # @return [Array]
     def build
-      workers.collect { |actor| actor.future(:build) }.map do |f|
-        begin
-          f.value
-        rescue; end
-      end
-      cache_manager.set_warmed
+      cache_manager.process_workers(workers)
     end
 
     # Issue a build command to all workers at the scheduled interval

--- a/lib/berkshelf/api/cache_builder/worker.rb
+++ b/lib/berkshelf/api/cache_builder/worker.rb
@@ -36,52 +36,6 @@ module Berkshelf::API
           raise RuntimeError, "must be implemented"
         end
 
-        def build
-          log.info "#{self} building..."
-          log.info "#{self} determining if the cache is stale..."
-          if stale?
-            log.info "#{self} cache is stale."
-            update_cache
-          else
-            log.info "#{self} cache is up to date."
-          end
-
-          log.info "clearing diff"
-          clear_diff
-        end
-
-        # @return [Array<Array<RemoteCookbook>, Array<RemoteCookbook>>]
-        def diff
-          @diff ||= cache_manager.diff(cookbooks)
-        end
-
-        def update_cache
-          created_cookbooks, deleted_cookbooks = diff
-
-          log.info "#{self} adding (#{created_cookbooks.length}) items..."
-          created_cookbooks.collect do |remote|
-            [ remote, future(:metadata, remote) ]
-          end.each do |remote, metadata|
-            cache_manager.add(remote, metadata.value)
-          end
-
-          log.info "#{self} removing (#{deleted_cookbooks.length}) items..."
-          deleted_cookbooks.each { |remote| cache_manager.remove(remote.name, remote.version) }
-
-          log.info "#{self} cache updated."
-          cache_manager.save
-        end
-
-        def stale?
-          created_cookbooks, deleted_cookbooks = diff
-          created_cookbooks.any? || deleted_cookbooks.any?
-        end
-
-        private
-
-          def clear_diff
-            @diff = nil
-          end
       end
 
       class << self

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -17,7 +17,7 @@ module Berkshelf::API
 
     server_name :cache_manager
     finalizer :finalize_callback
-    exclusive :add, :clear, :remove, :save
+    exclusive :merge
 
     attr_reader :cache
 
@@ -28,12 +28,33 @@ module Berkshelf::API
       every(SAVE_INTERVAL) { save }
     end
 
-    # @param [RemoteCookbook] cookbook
-    # @param [Ridley::Chef::Cookbook::Metadata] metadata
-    #
-    # @return [Hash]
-    def add(cookbook, metadata)
-      @cache.add(cookbook, metadata)
+    def process_workers(workers)
+      workers.collect { |worker| self.future(:process_worker, worker) }.map do |f|
+        begin
+          f.value
+        rescue; end
+      end
+
+      self.set_warmed
+    end
+
+    def process_worker(worker)
+      log.info "processing #{worker}"
+      remote_cookbooks = worker.cookbooks
+      log.info "found #{remote_cookbooks.size} cookbooks from #{worker}"
+      created_cookbooks, deleted_cookbooks = diff(remote_cookbooks)
+      log.debug "#{created_cookbooks.size} cookbooks to be added to the cache from #{worker}"
+      log.debug "#{deleted_cookbooks.size} cookbooks to be removed from the cache from #{worker}"
+
+      created_cookbooks.map! do |remote|
+        [ remote, worker.future(:metadata, remote) ]
+      end.map! do |remote, metadata|
+        [remote, metadata.value]
+      end
+
+      log.info "about to merge cookbooks"
+      merge(created_cookbooks, deleted_cookbooks)
+      log.info "#{self} cache updated."
     end
 
     # Clear any items added to the cache
@@ -54,44 +75,71 @@ module Berkshelf::API
     end
 
     def load_save
+      log.info "Loading save from #{self.class.cache_file}"
       @cache = DependencyCache.from_file(self.class.cache_file)
-    end
-
-    # Remove the cached item matching the given name and version
-    #
-    # @param [#to_s] name
-    # @param [#to_s] version
-    #
-    # @return [DependencyCache]
-    def remove(name, version)
-      @cache.remove(name, version)
-    end
-
-    def save
-      log.info "Saving the cache to: #{self.class.cache_file}"
-      cache.save(self.class.cache_file)
-      log.info "Cache saved!"
-    end
-
-    # @param [Array<RemoteCookbook>] cookbooks
-    #   An array of RemoteCookbooks representing all the cookbooks on the indexed site
-    #
-    # @return [Array(Array<RemoteCookbook>, Array<RemoteCookbook>)]
-    #   A tuple of Arrays of RemoteCookbooks
-    #   The first array contains items not in the cache
-    #   The second array contains items in the cache, but not in the cookbooks parameter
-    def diff(cookbooks)
-      known_cookbooks   = cache.cookbooks
-      created_cookbooks = cookbooks - known_cookbooks
-      deleted_cookbooks = known_cookbooks - cookbooks
-      [ created_cookbooks, deleted_cookbooks ]
+      log.info "Cache contains #{@cache.cookbooks.size} items"
     end
 
     private
 
+      def merge(created_cookbooks, deleted_cookbooks)
+        log.info "#{self} adding (#{created_cookbooks.length}) items..."
+        created_cookbooks.each do |remote_with_metadata|
+          remote, metadata = remote_with_metadata
+          add(remote, metadata)
+        end
+
+        log.info "#{self} removing (#{deleted_cookbooks.length}) items..."
+        deleted_cookbooks.each { |remote| remove(remote.name, remote.version) }
+
+        log.info "#{self} cache updated."
+        save
+      end
+
+      def save
+        log.info "Saving the cache to: #{self.class.cache_file}"
+        cache.save(self.class.cache_file)
+        log.info "Cache saved!"
+      end
+
+
+      # @param [RemoteCookbook] cookbook
+      # @param [Ridley::Chef::Cookbook::Metadata] metadata
+      #
+      # @return [Hash]
+      def add(cookbook, metadata)
+        log.debug "#{self} adding (#{cookbook.name}, #{cookbook.version})"
+        @cache.add(cookbook, metadata)
+      end
+
+      # Remove the cached item matching the given name and version
+      #
+      # @param [#to_s] name
+      # @param [#to_s] version
+      #
+      # @return [DependencyCache]
+      def remove(name, version)
+        log.debug "#{self} removing (#{name}, #{version})"
+        @cache.remove(name, version)
+      end
+
+      # @param [Array<RemoteCookbook>] cookbooks
+      #   An array of RemoteCookbooks representing all the cookbooks on the indexed site
+      #
+      # @return [Array(Array<RemoteCookbook>, Array<RemoteCookbook>)]
+      #   A tuple of Arrays of RemoteCookbooks
+      #   The first array contains items not in the cache
+      #   The second array contains items in the cache, but not in the cookbooks parameter
+      def diff(cookbooks)
+        known_cookbooks   = cache.cookbooks
+        created_cookbooks = cookbooks - known_cookbooks
+        deleted_cookbooks = known_cookbooks - cookbooks
+        [ created_cookbooks, deleted_cookbooks ]
+      end
+
       def finalize_callback
         log.info "Cache Manager shutting down..."
-        self.save
+        save
       end
   end
 end

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -28,8 +28,15 @@ module Berkshelf::API
       every(SAVE_INTERVAL) { save }
     end
 
+    # Loops through a list of workers and merges their cookbook sets into the cache
+    #
+    # @param [Array<Berkshelf::API::CacheBuilder::Worker::Base>] The workers for this cache
+    #
+    # @return void
     def process_workers(workers)
-      workers.collect { |worker| self.future(:process_worker, worker) }.map do |f|
+      [workers].flatten)
+      .collect { |worker| self.future(:process_worker, worker) }
+      .each do |f|
         begin
           f.value
         rescue; end
@@ -102,14 +109,13 @@ module Berkshelf::API
         log.info "Cache saved!"
       end
 
-
       # @param [RemoteCookbook] cookbook
       # @param [Ridley::Chef::Cookbook::Metadata] metadata
       #
       # @return [Hash]
       def add(cookbook, metadata)
         log.debug "#{self} adding (#{cookbook.name}, #{cookbook.version})"
-        @cache.add(cookbook, metadata)
+        cache.add(cookbook, metadata)
       end
 
       # Remove the cached item matching the given name and version
@@ -120,7 +126,7 @@ module Berkshelf::API
       # @return [DependencyCache]
       def remove(name, version)
         log.debug "#{self} removing (#{name}, #{version})"
-        @cache.remove(name, version)
+        cache.remove(name, version)
       end
 
       # @param [Array<RemoteCookbook>] cookbooks

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -34,7 +34,7 @@ module Berkshelf::API
     #
     # @return void
     def process_workers(workers)
-      [workers].flatten)
+      [workers].flatten
       .collect { |worker| self.future(:process_worker, worker) }
       .each do |f|
         begin

--- a/lib/berkshelf/api/remote_cookbook.rb
+++ b/lib/berkshelf/api/remote_cookbook.rb
@@ -1,3 +1,11 @@
 module Berkshelf::API
-  class RemoteCookbook < Struct.new(:name, :version, :location_type, :location_path); end
+  class RemoteCookbook < Struct.new(:name, :version, :location_type, :location_path)
+    def hash
+      "#{name}|#{version}".hash
+    end
+
+    def eql?(other)
+      self.hash == other.hash
+    end
+  end
 end

--- a/lib/berkshelf/api/remote_cookbook.rb
+++ b/lib/berkshelf/api/remote_cookbook.rb
@@ -1,11 +1,3 @@
 module Berkshelf::API
   class RemoteCookbook < Struct.new(:name, :version, :location_type, :location_path)
-    def hash
-      "#{name}|#{version}".hash
-    end
-
-    def eql?(other)
-      self.hash == other.hash
-    end
-  end
 end

--- a/lib/berkshelf/api/remote_cookbook.rb
+++ b/lib/berkshelf/api/remote_cookbook.rb
@@ -1,3 +1,3 @@
 module Berkshelf::API
-  class RemoteCookbook < Struct.new(:name, :version, :location_type, :location_path)
+  class RemoteCookbook < Struct.new(:name, :version, :location_type, :location_path); end
 end

--- a/spec/unit/berkshelf/api/cache_builder/worker/chef_server_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker/chef_server_spec.rb
@@ -35,25 +35,4 @@ describe Berkshelf::API::CacheBuilder::Worker::ChefServer do
       end
     end
   end
-
-  describe "#build" do
-    before do
-      Berkshelf::API::CacheManager.start
-      chef_cookbook("ruby", "1.0.0")
-      chef_cookbook("ruby", "2.0.0")
-      chef_cookbook("elixir", "3.0.0")
-      chef_cookbook("elixir", "3.0.1")
-    end
-
-    let(:cache) { Berkshelf::API::CacheManager.instance.cache }
-
-    it "adds each item to the cache" do
-      subject.build
-      expect(cache).to have_cookbook("ruby", "1.0.0")
-      expect(cache).to have_cookbook("ruby", "2.0.0")
-      expect(cache).to have_cookbook("elixir", "3.0.0")
-      expect(cache).to have_cookbook("elixir", "3.0.1")
-      expect(cache.cookbooks).to have(4).items
-    end
-  end
 end

--- a/spec/unit/berkshelf/api/cache_builder/worker_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker_spec.rb
@@ -37,44 +37,4 @@ describe Berkshelf::API::CacheBuilder::Worker::Base do
       end
     end
   end
-
-  let(:cache_manager) { double(:diff => :chicken) }
-  subject { described_class.new }
-
-  describe "#diff" do
-    it "should delegate to the cache_manager to calculate the diff" do
-      subject.should_receive(:cache_manager).and_return(cache_manager)
-      subject.should_receive(:cookbooks).and_return(:cookbooks)
-
-      expect(subject.diff).to eql(:chicken)
-    end
-
-    it "should memoize the diff to prevent recalculating" do
-      subject.should_receive(:cache_manager).exactly(1).times.and_return(cache_manager)
-      subject.should_receive(:cookbooks).and_return(:cookbooks)
-
-      subject.diff
-      subject.diff
-    end
-  end
-
-  describe "#clear_diff" do
-    it "should set the diff to nil" do
-      subject.should_receive(:cache_manager).and_return(cache_manager)
-      subject.should_receive(:cookbooks).and_return(:cookbooks)
-
-      subject.diff
-      expect(subject.instance_variable_get(:@diff)).to eql(:chicken)
-      subject.send(:clear_diff)
-      expect(subject.instance_variable_get(:@diff)).to eql(nil)
-    end
-
-    it "memoizes the diff to prevent recalculating" do
-      subject.should_receive(:cache_manager).exactly(1).times.and_return(cache_manager)
-      subject.should_receive(:cookbooks).and_return(:cookbooks)
-
-      subject.diff
-      subject.diff
-    end
-  end
 end

--- a/spec/unit/berkshelf/api/cache_builder_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder_spec.rb
@@ -9,11 +9,13 @@ describe Berkshelf::API::CacheBuilder do
     subject(:build) { instance.build }
     let(:workers) { [ double('worker') ] }
     let(:future) { double('future', value: nil) }
+    let(:cache_manager) { double('cache_manager') }
 
     before { instance.stub(workers: workers) }
 
-    it "sends a #build message to each worker" do
-      workers.each { |worker| worker.should_receive(:future).with(:build).and_return(future) }
+    it "asks the cache_manager to process all of its actors" do
+      instance.stub(:cache_manager).and_return(cache_manager)
+      cache_manager.should_receive(:process_workers).with(instance.workers).and_return(future)
       build
     end
   end

--- a/spec/unit/berkshelf/api/cache_manager_spec.rb
+++ b/spec/unit/berkshelf/api/cache_manager_spec.rb
@@ -72,10 +72,10 @@ describe Berkshelf::API::CacheManager do
     let(:comparison) { Array.new }
 
     before do
-      subject.add(cookbook_one, double(dependencies: nil, platforms: nil))
-      subject.add(cookbook_two, double(dependencies: nil, platforms: nil))
+      subject.send(:add, cookbook_one, double(dependencies: nil, platforms: nil))
+      subject.send(:add, cookbook_two, double(dependencies: nil, platforms: nil))
 
-      @created, @deleted = @diff = subject.diff(comparison)
+      @created, @deleted = @diff = subject.send(:diff, comparison)
     end
 
     it "returns two items" do


### PR DESCRIPTION
Refactor interactions between CacheBuilder, Works and CacheManager

CacheManager now hides the details of how it manages (add/remove) the
cache. Workers no longer reach in to the CacheManager to
add/remove/diff.

Knowledge of whether the cache is stale lives only in the CacheManager,
not in the workers.

The Workers now act as a Repository layer and are only a data source
used by CacheManager.
