### PR TITLE
Prioritize items added by specific builders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ rvm:
   - 1.9.3
   - 2.0.0
   - jruby-19mode
+jdk:
+  - openjdk6
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      jdk: openjdk6 
+    - rvm: 2.0.0
+      jdk: openjdk6
 notifications:
   irc:
     channels:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - jruby-19mode
-jdk:
-  - openjdk6
-matrix:
-  exclude:
-    - rvm: 1.9.3
-      jdk: openjdk6 
-    - rvm: 2.0.0
-      jdk: openjdk6
 notifications:
   irc:
     channels:

--- a/lib/berkshelf/api/cache_builder.rb
+++ b/lib/berkshelf/api/cache_builder.rb
@@ -19,9 +19,9 @@ module Berkshelf::API
       @worker_supervisor = WorkerSupervisor.new(@worker_registry)
       @building          = false
 
-      Application.config.endpoints.each do |endpoint|
+      Application.config.endpoints.each_with_index do |endpoint, index|
         endpoint_options = endpoint.options.to_hash.deep_symbolize_keys
-        @worker_supervisor.supervise(CacheBuilder::Worker[endpoint.type], endpoint_options)
+        @worker_supervisor.supervise(CacheBuilder::Worker[endpoint.type], endpoint_options.merge(priority: index))
       end
     end
 

--- a/lib/berkshelf/api/cache_builder/worker.rb
+++ b/lib/berkshelf/api/cache_builder/worker.rb
@@ -16,8 +16,11 @@ module Berkshelf::API
         include Berkshelf::API::Mixin::Services
 
         attr_reader :options
+        attr_reader :priority
 
-        def initialize(options = {}); end
+        def initialize(options = {})
+          @priority = options[:priority]
+        end
 
         # @abstract
         #

--- a/lib/berkshelf/api/cache_builder/worker/chef_server.rb
+++ b/lib/berkshelf/api/cache_builder/worker/chef_server.rb
@@ -19,7 +19,7 @@ module Berkshelf::API
             connection.cookbook.all.each do |cookbook, versions|
               versions.each do |version|
                 cookbook_versions << RemoteCookbook.new(cookbook, version, self.class.worker_type,
-                  @connection.server_url)
+                  @connection.server_url, priority)
               end
             end
           end

--- a/lib/berkshelf/api/cache_builder/worker/opscode.rb
+++ b/lib/berkshelf/api/cache_builder/worker/opscode.rb
@@ -19,7 +19,7 @@ module Berkshelf::API
               [ cookbook, connection.future(:versions, cookbook) ]
             end.each do |cookbook, versions|
               versions.value.each do |version|
-                cookbook_versions << RemoteCookbook.new(cookbook, version, self.class.worker_type, @connection.api_uri)
+                cookbook_versions << RemoteCookbook.new(cookbook, version, self.class.worker_type, @connection.api_uri, priority)
               end
             end
           end

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -11,7 +11,7 @@ module Berkshelf::API
     include Berkshelf::API::Logging
 
     extend Forwardable
-    def_delegators :@cache, :warmed?, :set_warmed
+    def_delegators :@cache, :warmed?, :set_warmed, :clear
 
     SAVE_INTERVAL = 30.0
 
@@ -105,13 +105,6 @@ module Berkshelf::API
       log.info "about to merge cookbooks"
       merge(created_cookbooks_with_metadata, deleted_cookbooks)
       log.info "#{self} cache updated."
-    end
-
-    # Clear any items added to the cache
-    #
-    # @return [Hash]
-    def clear
-      @cache.clear
     end
 
     # Check if the cache knows about the given cookbook version

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -140,9 +140,11 @@ module Berkshelf::API
       end
 
       def save
-        log.info "Saving the cache to: #{self.class.cache_file}"
-        cache.save(self.class.cache_file)
-        log.info "Cache saved!"
+        if warmed?
+          log.info "Saving the cache to: #{self.class.cache_file}"
+          cache.save(self.class.cache_file)
+          log.info "Cache saved!"
+        end
       end
 
       # @param [Array<RemoteCookbook>] cookbooks

--- a/lib/berkshelf/api/config.rb
+++ b/lib/berkshelf/api/config.rb
@@ -1,4 +1,5 @@
 require 'buff/config/json'
+require 'digest/sha1'
 
 module Berkshelf::API
   class Config < Buff::Config::JSON
@@ -24,5 +25,9 @@ module Berkshelf::API
           }
         }
       ]
+
+    def endpoints_checksum
+      Digest::SHA1.hexdigest(endpoints.collect {|x| x.to_hash }.to_s)
+    end
   end
 end

--- a/lib/berkshelf/api/dependency_cache.rb
+++ b/lib/berkshelf/api/dependency_cache.rb
@@ -41,6 +41,11 @@ module Berkshelf::API
     def initialize(contents = {})
       @warmed = false
       @cache  = Hash[contents].with_indifferent_access
+      if @cache['endpoints_checksum'] && (@cache['endpoints_checksum'] != Application.config.endpoints_checksum)
+        log.warn "Endpoints in config have changed - invalidating cache"
+        @cache.clear
+      end
+      @cache.delete('endpoints_checksum')
     end
 
     # @param [RemoteCookbook] cookbook
@@ -107,7 +112,9 @@ module Berkshelf::API
     #
     # @return [String]
     def to_json(options = {})
-      JSON.generate(to_hash, options)
+      output = to_hash
+      output['endpoints_checksum'] = Application.config.endpoints_checksum
+      JSON.generate(output, options)
     end
 
     # @return [Array<RemoteCookbook>]

--- a/lib/berkshelf/api/dependency_cache.rb
+++ b/lib/berkshelf/api/dependency_cache.rb
@@ -6,6 +6,7 @@ module Berkshelf::API
   #   {
   #     "cookbook_name" => {
   #       "x.y.z" => {
+  #         :endpoint_priority => 1,
   #         :dependencies => { "cookbook_name" => "constraint" },
   #         :platforms => { "platform" => "constraint" }
   #       }
@@ -51,6 +52,7 @@ module Berkshelf::API
       dependencies = metadata.dependencies || Hash.new
       @cache[cookbook.name.to_s] ||= Hash.new
       @cache[cookbook.name.to_s][cookbook.version.to_s] = {
+        endpoint_priority: cookbook.priority,
         platforms: platforms,
         dependencies: dependencies,
         location_type: cookbook.location_type,
@@ -113,7 +115,7 @@ module Berkshelf::API
       [].tap do |remote_cookbooks|
         @cache.each_pair do |name, versions|
           versions.each do |version, metadata|
-            remote_cookbooks << RemoteCookbook.new(name, version, metadata[:location_type], metadata[:location_path])
+            remote_cookbooks << RemoteCookbook.new(name, version, metadata[:location_type], metadata[:location_path], metadata[:endpoint_priority])
           end
         end
       end

--- a/lib/berkshelf/api/dependency_cache.rb
+++ b/lib/berkshelf/api/dependency_cache.rb
@@ -115,7 +115,7 @@ module Berkshelf::API
       [].tap do |remote_cookbooks|
         @cache.each_pair do |name, versions|
           versions.each do |version, metadata|
-            remote_cookbooks << RemoteCookbook.new(name, version, metadata[:location_type], metadata[:location_path], metadata[:endpoint_priority])
+            remote_cookbooks << RemoteCookbook.new(name, version, metadata['location_type'], metadata['location_path'], metadata['endpoint_priority'])
           end
         end
       end

--- a/lib/berkshelf/api/dependency_cache.rb
+++ b/lib/berkshelf/api/dependency_cache.rb
@@ -40,7 +40,7 @@ module Berkshelf::API
     # @param [Hash] contents
     def initialize(contents = {})
       @warmed = false
-      @cache  = Hash[contents]
+      @cache  = Hash[contents].with_indifferent_access
     end
 
     # @param [RemoteCookbook] cookbook
@@ -115,7 +115,7 @@ module Berkshelf::API
       [].tap do |remote_cookbooks|
         @cache.each_pair do |name, versions|
           versions.each do |version, metadata|
-            remote_cookbooks << RemoteCookbook.new(name, version, metadata['location_type'], metadata['location_path'], metadata['endpoint_priority'])
+            remote_cookbooks << RemoteCookbook.new(name, version, metadata[:location_type], metadata[:location_path], metadata[:endpoint_priority])
           end
         end
       end

--- a/lib/berkshelf/api/remote_cookbook.rb
+++ b/lib/berkshelf/api/remote_cookbook.rb
@@ -1,5 +1,5 @@
 module Berkshelf::API
-  class RemoteCookbook < Struct.new(:name, :version, :location_type, :location_path)
+  class RemoteCookbook < Struct.new(:name, :version, :location_type, :location_path, :priority)
     def hash
       "#{name}|#{version}".hash
     end

--- a/lib/berkshelf/api/site_connector/opscode.rb
+++ b/lib/berkshelf/api/site_connector/opscode.rb
@@ -92,7 +92,7 @@ module Berkshelf::API
       #
       # @return [String, nil]
       def download(name, version, destination = Dir.mktmpdir)
-        log.info "downloading #{name}(#{version})"
+        log.debug "downloading #{name}(#{version})"
         if uri = download_uri(name, version)
           archive = stream(uri)
           Archive.extract(archive.path, destination)

--- a/spec/unit/berkshelf/api/dependency_cache_spec.rb
+++ b/spec/unit/berkshelf/api/dependency_cache_spec.rb
@@ -67,6 +67,13 @@ describe Berkshelf::API::DependencyCache do
 
   subject { described_class.new(contents) }
 
+  context "when a new DependencyCache is created" do
+    it "should allow indifferent access to items in the cache" do
+      expect(subject[:chicken]).to be_a(Hash)
+      expect(subject[:chicken][:'1.0'][:dependencies]).to be_a(Hash)
+    end
+  end
+
   describe "#cookbooks" do
     it "should return a list of RemoteCookbooks" do
       expected_value = [


### PR DESCRIPTION
If you have two cache builders which attempt to add an item to the cache the builder which adds it's item first will win.

If an item is being added to the cache but an identical item is present but was added by a 
builder that is lower in the priority list the item should be replaced.

The order in which cache builders are configured should dictate their priority when adding items to the cache.
