### PR TITLE
Avoid thread exhaustion with large numbers of cookbooks

### DIFF
--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -79,6 +79,10 @@ module Berkshelf::API
       log.debug "#{created_cookbooks.size} cookbooks to be added to the cache from #{worker}"
       log.debug "#{deleted_cookbooks.size} cookbooks to be removed from the cache from #{worker}"
 
+      # Process metadata in chunks - Ridley cookbook resource uses a
+      # task_class TaskThread, which means each future gets its own
+      # thread. If we have many (>2000) cookbooks we can easily
+      # exhaust the available threads on the system.
       created_cookbooks_with_metadata = []
       until created_cookbooks.empty?
         work = created_cookbooks.slice!(0,500)


### PR DESCRIPTION
Each cookbook gets a future - and in Ridley that means a new thread. This
change limits the number of concurrent metadata calls to 500 to avoid
exhausting all the threads on the system.
