### PR TITLE
Resilient cookbook download

### DIFF
--- a/berkshelf-api.gemspec
+++ b/berkshelf-api.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'reel', '>= 0.4.0'
   spec.add_dependency 'grape', '~> 0.5.0'
   spec.add_dependency 'hashie', '>= 2.0.4'
+  spec.add_dependency 'httpclient'
   spec.add_dependency 'faraday'
   spec.add_dependency 'retryable', '~> 1.3.3'
   spec.add_dependency 'archive', '= 0.0.2'

--- a/lib/berkshelf/api/site_connector/opscode.rb
+++ b/lib/berkshelf/api/site_connector/opscode.rb
@@ -36,9 +36,8 @@ module Berkshelf::API
       #   time to wait between retries
       attr_reader :retry_interval
 
-      # @param [Faraday::Connection] connection
-      #   Optional parameter for setting the connection object
-      #   This should only be set manually for testing
+      # @param [Hash] options
+      #   Optional parameters for configuration of retry settings and URL
       def initialize(options = {})
         options  = { url: V1_API, retries: 5, retry_interval: 0.5 }.merge(options)
         @api_uri = options[:url]
@@ -144,7 +143,7 @@ module Berkshelf::API
         local.binmode
 
         retryable(tries: retries, on: OpenURI::HTTPError, sleep: retry_interval) do
-          open(target, 'rb', connection.headers) do |remote|
+          open(target, 'rb') do |remote|
             local.write(remote.read)
           end
         end


### PR DESCRIPTION
The open-uri implementation doesn't allow redirects from http:// to
https:// locations. Therefore, open-uri got replaced with httpclient.
This library was chosen as it was already part of the dependency tree
(ridley -> winrm -> httpclient) and solves the problem without
introducing any overhead.
