### PR TITLE
Update archive gem version

### DIFF
--- a/berkshelf-api.gemspec
+++ b/berkshelf-api.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hashie', '>= 2.0.4'
   spec.add_dependency 'faraday'
   spec.add_dependency 'retryable', '~> 1.3.3'
-  spec.add_dependency 'archive', '= 0.0.2'
+  spec.add_dependency 'archive', '= 0.0.4'
   spec.add_dependency 'buff-config', '~> 0.1'
 
   spec.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
In order to specify a custom location of libarchive.so, a newer version of archive gem is necessary.

The changelog, couldn't see any issues: https://github.com/erikh/archive/compare/v0.0.2...v0.0.4
