### PR TITLE
Status end point

### DIFF
--- a/lib/berkshelf/api/endpoint/v1.rb
+++ b/lib/berkshelf/api/endpoint/v1.rb
@@ -22,7 +22,7 @@ module Berkshelf::API
 
       desc "health check"
       get 'status' do
-        {status: 'ok', version: Berkshelf::API::VERSION}
+        {status: 'ok', version: Berkshelf::API::VERSION, cache_status: cache_manager.warmed? ? 'ok' : 'warming'}
       end
     end
   end

--- a/lib/berkshelf/api/endpoint/v1.rb
+++ b/lib/berkshelf/api/endpoint/v1.rb
@@ -19,6 +19,11 @@ module Berkshelf::API
           status 503
         end
       end
+
+      desc "health check"
+      get 'status' do
+        {status: 'ok', version: Berkshelf::API::VERSION}
+      end
     end
   end
 end

--- a/spec/unit/berkshelf/api/endpoint/v1_spec.rb
+++ b/spec/unit/berkshelf/api/endpoint/v1_spec.rb
@@ -30,11 +30,18 @@ describe Berkshelf::API::Endpoint::V1 do
   end
 
   describe "GET /status" do
-    before { get '/status' }
-
     subject { last_response }
 
-    its(:status) { should be(200) }
-    its(:body) { should eq({status: 'ok', version: Berkshelf::API::VERSION}.to_json) }
+    context "the cache has been warmed" do
+      before { cache_manager.set_warmed; get '/status'  }
+      its(:status) { should be(200) }
+      its(:body) { should eq({status: 'ok', version: Berkshelf::API::VERSION, cache_status: 'ok'}.to_json) }
+    end
+
+    context "the cache is still warming" do
+      before { get '/status' }
+      its(:status) { should be(200) }
+      its(:body) { should eq({status: 'ok', version: Berkshelf::API::VERSION, cache_status: 'warming'}.to_json) }
+    end
   end
 end

--- a/spec/unit/berkshelf/api/endpoint/v1_spec.rb
+++ b/spec/unit/berkshelf/api/endpoint/v1_spec.rb
@@ -28,4 +28,13 @@ describe Berkshelf::API::Endpoint::V1 do
       its(:headers) { should have_key("Retry-After") }
     end
   end
+
+  describe "GET /status" do
+    before { get '/status' }
+
+    subject { last_response }
+
+    its(:status) { should be(200) }
+    its(:body) { should eq({status: 'ok', version: Berkshelf::API::VERSION}.to_json) }
+  end
 end


### PR DESCRIPTION
Would be nice to have a status endpoint that returns some static text, and maybe the service version and how long it has been up. Helpful for stuff like health checks since on first boot, /universe/ might not be available (also its a huge transfer).
