### PR TITLE
Stick to faraday-0.8.8 version  

### DIFF
--- a/berkshelf-api.gemspec
+++ b/berkshelf-api.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'reel', '>= 0.4.0'
   spec.add_dependency 'grape', '~> 0.5.0'
   spec.add_dependency 'hashie', '>= 2.0.4'
-  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday', '~> 0.8.0'
   spec.add_dependency 'retryable', '~> 1.3.3'
   spec.add_dependency 'archive', '= 0.0.2'
   spec.add_dependency 'buff-config', '~> 0.1'


### PR DESCRIPTION
After `gem install berkshelf-api`, when trying to run berks-api with clean rvm ruby-2.0.0 installation, it breaks because latest faraday version _0.9.0.rc6_. 
If I manually install  faraday-0.8.8, berks-api runs ok.

```
root@59005f2f3da4:/# berks-api
/usr/local/rvm/gems/ruby-2.0.0-p353@global/gems/faraday-0.9.0.rc6/lib/faraday.rb:99:in `method_missing': undefined method `register_middleware' for #<Faraday::Connection:0x00000001dbb978> (NoMethodError)
    from /usr/local/rvm/rubies/ruby-2.0.0-p353/lib/ruby/gems/2.0.0/gems/ridley-2.4.0/lib/ridley/middleware/chef_auth.rb:90:in `<top (required)>'
    from /usr/local/rvm/rubies/ruby-2.0.0-p353/lib/ruby/gems/2.0.0/gems/ridley-2.4.0/lib/ridley/middleware.rb:9:in `require_relative'
    from /usr/local/rvm/rubies/ruby-2.0.0-p353/lib/ruby/gems/2.0.0/gems/ridley-2.4.0/lib/ridley/middleware.rb:9:in `block in <top (required)>'
    from /usr/local/rvm/rubies/ruby-2.0.0-p353/lib/ruby/gems/2.0.0/gems/ridley-2.4.0/lib/ridley/middleware.rb:8:in `each'
    from /usr/local/rvm/rubies/ruby-2.0.0-p353/lib/ruby/gems/2.0.0/gems/ridley-2.4.0/lib/ridley/middleware.rb:8:in `<top (required)>'
    from /usr/local/rvm/gems/ruby-2.0.0-p353@global/gems/ridley-2.4.0/lib/ridley.rb:75:in `require_relative'
    from /usr/local/rvm/gems/ruby-2.0.0-p353@global/gems/ridley-2.4.0/lib/ridley.rb:75:in `<module:Ridley>'
    from /usr/local/rvm/gems/ruby-2.0.0-p353@global/gems/ridley-2.4.0/lib/ridley.rb:13:in `<top (required)>'
    from /usr/local/rvm/rubies/ruby-2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/local/rvm/rubies/ruby-2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/local/rvm/gems/ruby-2.0.0-p353@global/gems/berkshelf-api-1.1.0/lib/berkshelf/api.rb:4:in `<top (required)>'
    from /usr/local/rvm/rubies/ruby-2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/local/rvm/rubies/ruby-2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/local/rvm/gems/ruby-2.0.0-p353@global/gems/berkshelf-api-1.1.0/lib/berkshelf/api/srv_ctl.rb:62:in `start'
    from /usr/local/rvm/gems/ruby-2.0.0-p353@global/gems/berkshelf-api-1.1.0/lib/berkshelf/api/srv_ctl.rb:48:in `run'
    from /usr/local/rvm/gems/ruby-2.0.0-p353@global/gems/berkshelf-api-1.1.0/bin/berks-api:5:in `<top (required)>'
    from /usr/local/rvm/gems/ruby-2.0.0-p353@global/bin/berks-api:23:in `load'
    from /usr/local/rvm/gems/ruby-2.0.0-p353@global/bin/berks-api:23:in `<main>'
    from /usr/local/rvm/gems/ruby-2.0.0-p353@global/bin/ruby_executable_hooks:15:in `eval'
    from /usr/local/rvm/gems/ruby-2.0.0-p353@global/bin/ruby_executable_hooks:15:in `<main>'
```
