### PR TITLE
Auto paginate repository list from Octokit

### DIFF
--- a/lib/berkshelf/api/cache_builder/worker/github.rb
+++ b/lib/berkshelf/api/cache_builder/worker/github.rb
@@ -17,7 +17,7 @@ module Berkshelf::API
         #   authentication token for accessing the Github organization. This is necessary
         #   since Github throttles unauthenticated API requests
         def initialize(options = {})
-          @connection   = Octokit::Client.new(access_token: options[:access_token])
+          @connection   = Octokit::Client.new(access_token: options[:access_token], auto_paginate: true)
           @organization = options[:organization]
           super(options)
         end


### PR DESCRIPTION
- Only 30 repositories are returned by default
- The auto_paginate example in the Octokit documentation is for issues in
  rails/rails which returns over 700 objects, even opscode-cookbooks has
  far fewer repositories.
