### PR TITLE
Friendlier logging

### DIFF
--- a/lib/berkshelf/api/cache_builder/worker.rb
+++ b/lib/berkshelf/api/cache_builder/worker.rb
@@ -22,6 +22,15 @@ module Berkshelf::API
           @priority = options[:priority]
         end
 
+        # @param [String] data
+        #   any string to append to the worker_type
+        # @return [String]
+        def to_s(data = nil)
+          string = self.class.worker_type.dup
+          string << ": #{data}" if data
+          string
+        end
+
         # @abstract
         #
         # @param [RemoteCookbook] remote

--- a/lib/berkshelf/api/cache_builder/worker.rb
+++ b/lib/berkshelf/api/cache_builder/worker.rb
@@ -22,13 +22,9 @@ module Berkshelf::API
           @priority = options[:priority]
         end
 
-        # @param [String] data
-        #   any string to append to the worker_type
         # @return [String]
-        def to_s(data = nil)
-          string = self.class.worker_type.dup
-          string << ": #{data}" if data
-          string
+        def to_s
+          friendly_name
         end
 
         # @abstract
@@ -47,6 +43,17 @@ module Berkshelf::API
         def cookbooks
           raise RuntimeError, "must be implemented"
         end
+
+        private
+
+          # @param [String] data
+          #   any string to append to the worker_type
+          # @return [String]
+          def friendly_name(data = nil)
+            string = self.class.worker_type.dup
+            string << ": #{data}" if data
+            string
+          end
       end
 
       class << self

--- a/lib/berkshelf/api/cache_builder/worker/chef_server.rb
+++ b/lib/berkshelf/api/cache_builder/worker/chef_server.rb
@@ -26,7 +26,7 @@ module Berkshelf::API
 
         # @return [String]
         def to_s
-          super(url)
+          friendly_name(url)
         end
 
         # @return [Array<RemoteCookbook>]

--- a/lib/berkshelf/api/cache_builder/worker/chef_server.rb
+++ b/lib/berkshelf/api/cache_builder/worker/chef_server.rb
@@ -6,6 +6,9 @@ module Berkshelf::API
 
         finalizer :finalize_callback
 
+        # @return [String]
+        attr_reader :url
+
         # @option options [String] :url
         #   the URL of the target Chef Server
         # @option options [String] :client_name
@@ -15,9 +18,15 @@ module Berkshelf::API
         # @option options [Boolean] :ssl_verify
         #   turn ssl verification off if you have an unsigned SSL certificate
         def initialize(options = {})
-          @connection = Ridley::Client.new_link(server_url: options[:url], client_key: options[:client_key],
+          @url = options[:url]
+          @connection = Ridley::Client.new_link(server_url: url, client_key: options[:client_key],
             client_name: options[:client_name], ssl: { verify: options[:ssl_verify] })
           super
+        end
+
+        # @return [String]
+        def to_s
+          super(url)
         end
 
         # @return [Array<RemoteCookbook>]

--- a/lib/berkshelf/api/cache_builder/worker/file_store.rb
+++ b/lib/berkshelf/api/cache_builder/worker/file_store.rb
@@ -16,7 +16,7 @@ module Berkshelf::API
 
         # @return [String]
         def to_s
-          super(path)
+          friendly_name(path)
         end
 
         # @return [Array<RemoteCookbook>]

--- a/lib/berkshelf/api/cache_builder/worker/file_store.rb
+++ b/lib/berkshelf/api/cache_builder/worker/file_store.rb
@@ -14,6 +14,11 @@ module Berkshelf::API
           super(options)
         end
 
+        # @return [String]
+        def to_s
+          super(path)
+        end
+
         # @return [Array<RemoteCookbook>]
         #  The list of cookbooks this builder can find
         def cookbooks

--- a/lib/berkshelf/api/cache_builder/worker/github.rb
+++ b/lib/berkshelf/api/cache_builder/worker/github.rb
@@ -24,7 +24,7 @@ module Berkshelf::API
 
         # @return [String]
         def to_s
-          super(organization)
+          friendly_name(organization)
         end
 
         # @return [Array<RemoteCookbook>]

--- a/lib/berkshelf/api/cache_builder/worker/github.rb
+++ b/lib/berkshelf/api/cache_builder/worker/github.rb
@@ -22,6 +22,11 @@ module Berkshelf::API
           super(options)
         end
 
+        # @return [String]
+        def to_s
+          super(organization)
+        end
+
         # @return [Array<RemoteCookbook>]
         #  The list of cookbooks this builder can find
         def cookbooks

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -23,7 +23,7 @@ module Berkshelf::API
     attr_reader :cache
 
     def initialize
-      log.info "Cache Manager starting..."
+      log.info "#{self} starting..."
       @cache = DependencyCache.new
       load_save if File.exist?(self.class.cache_file)
       every(SAVE_INTERVAL) { save }
@@ -122,6 +122,11 @@ module Berkshelf::API
       log.info "Loading save from #{self.class.cache_file}"
       @cache = DependencyCache.from_file(self.class.cache_file)
       log.info "Cache contains #{@cache.cookbooks.size} items"
+    end
+
+    # @return [String]
+    def to_s
+      "Cache manager"
     end
 
     private

--- a/lib/berkshelf/api/cache_manager.rb
+++ b/lib/berkshelf/api/cache_manager.rb
@@ -79,9 +79,9 @@ module Berkshelf::API
 
     # @param [CacheBuilder::Worker::Base] worker
     def process_worker(worker)
-      log.info "processing #{worker}"
+      log.info "Processing #{worker}"
       remote_cookbooks = worker.cookbooks
-      log.info "found #{remote_cookbooks.size} cookbooks from #{worker}"
+      log.info "Found #{remote_cookbooks.size} cookbooks from #{worker}"
       created_cookbooks, deleted_cookbooks = diff(remote_cookbooks, worker.priority)
       log.debug "#{created_cookbooks.size} cookbooks to be added to the cache from #{worker}"
       log.debug "#{deleted_cookbooks.size} cookbooks to be removed from the cache from #{worker}"
@@ -93,7 +93,7 @@ module Berkshelf::API
       created_cookbooks_with_metadata = []
       until created_cookbooks.empty?
         work = created_cookbooks.slice!(0,500)
-        log.info "processing metadata for #{work.size} cookbooks with #{created_cookbooks.size} remaining on #{worker}"
+        log.info "Processing metadata for #{work.size} cookbooks with #{created_cookbooks.size} remaining on #{worker}"
         work.map! do |remote|
           [ remote, worker.future(:metadata, remote) ]
         end.map! do |remote, metadata|
@@ -103,7 +103,7 @@ module Berkshelf::API
         created_cookbooks_with_metadata += work.compact
       end
 
-      log.info "about to merge cookbooks"
+      log.info "About to merge cookbooks"
       merge(created_cookbooks_with_metadata, deleted_cookbooks)
       log.info "#{self} cache updated."
     end

--- a/lib/berkshelf/api/site_connector/opscode.rb
+++ b/lib/berkshelf/api/site_connector/opscode.rb
@@ -99,14 +99,14 @@ module Berkshelf::API
       #
       # @return [String, nil]
       def download(name, version, destination = Dir.mktmpdir)
-        log.debug "downloading #{name}(#{version})"
+        log.debug "Downloading #{name}(#{version})"
         if uri = download_uri(name, version)
           begin
             archive = stream(uri)
             Archive.extract(archive.path, destination)
             destination
           rescue => ex
-            log.warn "error downloading/extracting #{name} (#{version}): #{ex}"
+            log.warn "Error downloading/extracting #{name} (#{version}): #{ex}"
             nil
           ensure
             archive.unlink unless archive.nil?

--- a/spec/support/human_reaable.rb
+++ b/spec/support/human_reaable.rb
@@ -1,0 +1,9 @@
+shared_examples_for "a human-readable string" do
+  it "does not start with Ruby object notation" do
+    expect(subject.to_s).to_not start_with("#<")
+  end
+
+  it "does not contain a hex prefix" do
+    expect(subject.to_s).to_not match(%r{0x[0-9a-f]+})
+  end
+end

--- a/spec/unit/berkshelf/api/cache_builder/worker/chef_server_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker/chef_server_spec.rb
@@ -11,6 +11,8 @@ describe Berkshelf::API::CacheBuilder::Worker::ChefServer do
       client_key: fixtures_path.join("reset.pem"))
   end
 
+  it_behaves_like "a human-readable string"
+
   describe "#cookbooks" do
     before do
       chef_cookbook("ruby", "1.0.0")

--- a/spec/unit/berkshelf/api/cache_builder/worker/file_store_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker/file_store_spec.rb
@@ -10,6 +10,8 @@ describe Berkshelf::API::CacheBuilder::Worker::FileStore do
     described_class.new(path: fixtures_path.join("cookbooks"))
   end
 
+  it_behaves_like "a human-readable string"
+
   describe "#cookbooks" do
     it "returns an array containing an item for each valid cookbook on the server" do
       expect(subject.cookbooks).to have(1).items

--- a/spec/unit/berkshelf/api/cache_builder/worker/github_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker/github_spec.rb
@@ -44,6 +44,8 @@ describe Berkshelf::API::CacheBuilder::Worker::Github do
     described_class.new(organization: "opscode-cookbooks", access_token: "asdf")
   end
 
+  it_behaves_like "a human-readable string"
+
   describe "#cookbooks" do
     before do
       expect(connection).to receive(:organization_repositories) { repos }

--- a/spec/unit/berkshelf/api/cache_builder/worker/opscode_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker/opscode_spec.rb
@@ -20,6 +20,8 @@ describe Berkshelf::API::CacheBuilder::Worker::Opscode do
     described_class.new
   end
 
+  it_behaves_like "a human-readable string"
+
   describe "#cookbooks" do
     let(:location_type) { described_class.worker_type }
     let(:location_path) { Berkshelf::API::SiteConnector::Opscode::V1_API}

--- a/spec/unit/berkshelf/api/cache_manager_spec.rb
+++ b/spec/unit/berkshelf/api/cache_manager_spec.rb
@@ -41,6 +41,8 @@ describe Berkshelf::API::CacheManager do
 
   subject { described_class.new }
 
+  it_behaves_like "a human-readable string"
+
   describe "#add" do
     pending
   end


### PR DESCRIPTION
Cleans up the log output to show friendlier strings instead of Ruby object notation

```
chef_server: http://localhost:4000
file_store: /Users/Justin/cookbooks
github: justincampbell
opscode
```
