### PR TITLE
Github Enterprise fix #79

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ a Github Enterprise server within your own organization
         "access_token": "",
         "api_endpoint": "https://github.enterprise.local/api/v3",
         "web_endpoint": "https://github.enterprise.local",
-        "sll_verify": true
+        "ssl_verify": true
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ You may configure the endpoints to index by editing the JSON configuration file 
 ### Github Organization
 
 Github limits the rate of requests to their API if not authenticated. For this reason the access_token option
-is required.
+is required. The api_endpoint, web_endpoint and ssl_verify options are only needed when you want to point to
+a Github Enterprise server within your own organization
 
 ```json
 {
@@ -73,7 +74,10 @@ is required.
       "type": "github",
       "options": {
         "organization": "opscode-cookbooks",
-        "access_token": ""
+        "access_token": "",
+        "api_endpoint": "https://github.enterprise.local/api/v3",
+        "web_endpoint": "https://github.enterprise.local",
+        "sll_verify": true
       }
     }
   ]

--- a/lib/berkshelf/api/cache_builder/worker/github.rb
+++ b/lib/berkshelf/api/cache_builder/worker/github.rb
@@ -17,7 +17,9 @@ module Berkshelf::API
         #   authentication token for accessing the Github organization. This is necessary
         #   since Github throttles unauthenticated API requests
         def initialize(options = {})
-          @connection   = Octokit::Client.new(access_token: options[:access_token], auto_paginate: true)
+          @connection   = Octokit::Client.new(access_token: options[:access_token], auto_paginate: true,
+            api_endpoint: options[:api_endpoint], web_endpoint: options[:web_endpoint],
+            connection_options: {ssl: {verify: options[:ssl_verify].nil? ? true : options[:ssl_verify]}})
           @organization = options[:organization]
           super(options)
         end


### PR DESCRIPTION
Github cache builder is now configurable so you can also point to your own Github Enterprise server. If you do not specify any of the new config options, the builders' behaviour is exactly the same as before.

For auto_paginate to work with Github Enterprise an additional fix is needed in the Octokit.rb package. A patch for that is already supplied to Octokit.rb (https://github.com/octokit/octokit.rb/pull/440)
