### PR TITLE
Gemfile: only list 'rspec' once

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ group :development do
   gem 'coolline'
   gem 'fuubar'
   gem 'redcarpet', platforms: :ruby
-  gem 'rspec'
   gem 'yard'
 
   gem 'guard'
@@ -33,7 +32,7 @@ group :development do
   end
 end
 
-group :test do
+group :development, :test do
   gem 'rack-test'
   gem 'rspec'
   gem 'spork'


### PR DESCRIPTION
This is to resolve this warning from bundler:

```
Your Gemfile lists the gem rspec (>= 0) more than once.
```

   You should probably keep only one of them.
   While it's not a problem now, it could cause errors if you change the
   version of just one of them later.
