### PR TITLE
gitignore: ctags files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+/tags


### PR DESCRIPTION
Ignore any tags files, for people who use ctags to browse ruby code.
