### PR TITLE
Changed the location_path so it contains the full repo URL

### DIFF
--- a/lib/berkshelf/api/cache_builder/worker/github.rb
+++ b/lib/berkshelf/api/cache_builder/worker/github.rb
@@ -41,7 +41,7 @@ module Berkshelf::API
 
                     if cookbook_metadata.version.to_s == match[:version].to_s
                       cookbook_versions << RemoteCookbook.new(repo.name, cookbook_metadata.version,
-                        self.class.worker_type, repo.full_name, priority)
+                        self.class.worker_type, repo.html_url, priority)
                     else
                       log.warn "Version found in metadata for #{repo.name} (#{tag.name}) does not " +
                         "match the tag. Got #{cookbook_metadata.version}."


### PR DESCRIPTION
This extra info is needed by the berks command when downloading the
cookbooks from Git based on the given API info. Without this extra info
it’s impossible to determine which Github location should be used (when
using multiple organisations and/or Github Enterprise organisations)

This change needs to be merged in correlation with
berkshelf/berkshelf#1045
