### PR TITLE
GitLab public repository support

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -6,7 +6,23 @@ guard 'spork' do
   watch(%r{^spec/support/.+\.rb$}) { :rspec }
 end
 
-guard 'rspec', cli: "--color --drb --format Fuubar", all_on_start: false, all_after_pass: false do
+guard 'yard', stdout: '/dev/null', stderr: '/dev/null' do
+  watch(%r{app/.+\.rb})
+  watch(%r{lib/.+\.rb})
+  watch(%r{ext/.+\.c})
+end
+
+guard(
+  'rspec',
+  cmd: "bundle exec rspec --drb --color -f progress",
+  failed_mode: :keep,
+  spec_paths: [
+    'spec/unit/gitlab_client_spec.rb',
+    'spec/unit/berkshelf/api/cache_builder/worker/gitlab_spec.rb'
+  ],
+  all_on_start: true,
+  all_after_pass: true
+) do
   watch(%r{^spec/unit/.+_spec\.rb$})
 
   watch(%r{^lib/(.+)\.rb$})           { |m| "spec/unit/#{m[1]}_spec.rb" }

--- a/README.md
+++ b/README.md
@@ -120,6 +120,32 @@ a GitHub Enterprise server within your own organization
 }
 ```
 
+### GitLab group
+
+This searches a [GitLab](https://gitlab.com/) group looking for *public*
+repositories that contain cookbooks with [semver](http://semver.org/) tags
+(e.g. "v1.2.3").
+
+Requirements:
+
+* A private token; available via your account page.
+* GitLab version 6.6.0 or newer
+
+```json
+{
+  "endpoints": [
+    {
+      "type": "gitlab",
+      "options": {
+        "group": "my-cookbooks",
+        "private_token": "",
+        "url": "https://gitlab.example.com/"
+      }
+    }
+  ]
+}
+```
+
 ### FileStore directory
 
 A local directory containing cookbooks.

--- a/lib/berkshelf/api/cache_builder/worker/gitlab.rb
+++ b/lib/berkshelf/api/cache_builder/worker/gitlab.rb
@@ -1,0 +1,139 @@
+require 'gitlab_client'
+require 'semverse'
+
+module Berkshelf::API
+  class CacheBuilder
+    module Worker
+      class Gitlab < Worker::Base
+        worker_type 'gitlab'
+
+        # @return [String]
+        attr_reader :group
+
+        # @option options [String] :group
+        #   the group to crawl for cookbooks
+        # @option options [String] :url
+        #   the api URL, usually something like https://gitlab.example.com
+        # @option options [String] :private_token
+        #   authentication token for accessing GitLab.
+        def initialize(options = {})
+          @gitlab_url           = options[:url]
+          @group                = options[:group]
+
+          endpoint = @gitlab_url.chomp('/') + '/api/v3'
+          token = options[:private_token]
+          @connection = ::GitlabClient.new endpoint, token
+
+          log.warn "You have configured a GitLab endpoint to index the #{@group} group."
+          log.warn "Using unfinalized artifacts, such as cookbooks retrieved from Git, to satisfiy your"
+          log.warn "dependencies is *STRONGLY FROWNED UPON* and potentially *DANGEROUS*."
+          log.warn ""
+          log.warn "Please consider setting up a release process for the cookbooks you wish to retrieve from this"
+          log.warn "GitLab group where the cookbook is uploaded into a Hosted Chef organization, an internal"
+          log.warn "Chef Server, or the community site, and then replace this endpoint with a chef_server endpoint."
+
+          super(options)
+        end
+
+        # @return [String]
+        def to_s
+          friendly_name "#{@gitlab_url}/groups/#{group}"
+        end
+
+        # @return [Array<RemoteCookbook>]
+        #  The list of cookbooks this builder can find
+        def cookbooks
+          [].tap do |cookbook_versions|
+            log.debug "#{self} Searching for cookbooks..."
+            connection.group(group).projects.each do |project|
+              next unless project.public?
+
+              tags = project.tags.select { |tag| tag =~ /\Av[0-9][0-9.]+\Z/ }
+              tags.each do |tag|
+                remote_cookbook = find_remote_cookbook(project, tag)
+                cookbook_versions << remote_cookbook if remote_cookbook
+              end
+            end
+          end
+        rescue ::GitlabClient::Error => ex
+          log.warn "#{self} #{ex}"
+          []
+        end
+
+        # Return the metadata of the given RemoteCookbook. If the metadata could not be found or parsed
+        # nil is returned.
+        #
+        # @param [RemoteCookbook] remote
+        #
+        # @return [Ridley::Chef::Cookbook::Metadata, nil]
+        def metadata(remote)
+          load_metadata(remote.external_id, "v#{remote.version}")
+        end
+
+        private
+
+        attr_reader :connection
+
+        # Fetches a cookbook for a given project and tag
+        #
+        # @param [GitlabClient::Project] project
+        # @param [String] tag
+        # @return [RemoteCookbook]
+        def find_remote_cookbook(project, tag)
+          begin
+            return nil unless cookbook_metadata = load_metadata(project.id, tag)
+
+            if cookbook_metadata.version.to_s == tag[1..-1]
+              location_type = 'uri'
+              location_path = "#{project.web_url}/repository/archive.tar.gz?ref=#{tag}"
+              return RemoteCookbook.new(cookbook_metadata.name,
+                                        cookbook_metadata.version,
+                                        location_type,
+                                        location_path,
+                                        priority,
+                                        project.id
+                                       )
+            else
+              log.warn "Version found in metadata for #{project.full_path} (#{tag}) does not " +
+                "match the tag. Got #{cookbook_metadata.version}."
+            end
+          rescue ::GitlabClient::Error => ex
+            log.warn "#{self} Unable to load group: #{ex}"
+          rescue Semverse::InvalidVersionFormat
+            log.debug "#{self} Ignoring tag #{tag}. Does not conform to semver."
+          end
+          nil
+        end
+
+        # Helper function for loading metadata from a particular ref in a Gitlab repository
+        #
+        # @param [String] project_id
+        #   name of repository to load from
+        # @param [String] ref
+        #   reference, tag, or branch to load from
+        #
+        # @return [Ridley::Chef::Cookbook::Metadata, nil]
+        def load_metadata(project_id, ref)
+          project = connection.find_project_by_id(project_id)
+          content = project.file(Ridley::Chef::Cookbook::Metadata::RAW_FILE_NAME, ref)
+
+          cookbook_metadata = Ridley::Chef::Cookbook::Metadata.new
+          cookbook_metadata.instance_eval(content)
+          cookbook_metadata
+        rescue ::GitlabClient::NoSuchFile => ex
+          log.warn("#{self} #{ex}")
+          nil
+        rescue ::GitlabClient::NoSuchProject => ex
+          log.warn("#{self} #{ex}")
+          nil
+        rescue ::GitlabClient::Error => ex
+          log.warn("#{self} Please make sure gitlab is using version 6.6.0 or newer")
+          nil
+        rescue => ex
+          log.warn("#{self} Error getting metadata for project id #{project_id} with ref #{ref}: #{ex}")
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/berkshelf/api/remote_cookbook.rb
+++ b/lib/berkshelf/api/remote_cookbook.rb
@@ -1,5 +1,5 @@
 module Berkshelf::API
-  class RemoteCookbook < Struct.new(:name, :version, :location_type, :location_path, :priority)
+  class RemoteCookbook < Struct.new(:name, :version, :location_type, :location_path, :priority, :external_id)
     def hash
       "#{name}|#{version}".hash
     end

--- a/lib/gitlab_client.rb
+++ b/lib/gitlab_client.rb
@@ -1,0 +1,172 @@
+require 'json'
+require 'faraday'
+require 'base64'
+
+# API client for talking to GitLab servers
+class GitlabClient
+  attr_reader :endpoint, :private_token
+
+  class Error < StandardError; end
+
+  class UnknownFileEncoding < Error; end
+  class FourOhFour          < Error; end
+  class NoSuchFile          < FourOhFour; end
+  class NoSuchGroup         < FourOhFour; end
+  class NoSuchProject       < FourOhFour; end
+
+  # @param [String] endpoint
+  #   The URL endpoint. e.g. http://gitlab.example.com/api/v3/
+  # @param [String] private_token
+  #   A user's private access token
+  # @param [Logger|NilClass] logger
+  #   The a logger for sending event notifications to. Warning, it is
+  #   very verbose!
+  def initialize(endpoint, private_token, logger = nil)
+    @endpoint, @private_token, @logger = endpoint, private_token, logger
+  end
+
+  # @param [String] group_path
+  #   The API path for the group
+  # @return [GitlabClient::Group]
+  def group(group_path)
+    groups
+      .select { |g| g.path == group_path }
+      .first
+      .tap { |g| fail NoSuchGroup, "No such group: #{group_path}" unless g }
+  end
+
+  # @return [Array<GitlabClient::Group>]
+  def groups
+    get('groups').map { |g| Group.new self, g }
+  end
+
+  # @param [Fixnum] project_id
+  #   The ID for a project.
+  # @return [GitlabClient::Project]
+  def find_project_by_id(project_id)
+    Project.new self, get("projects/#{project_id}")
+  end
+
+  # @return [Array<Hash>] the remote JSON data
+  # @api private
+  def _projects_for_group_id(group_id)
+    get("groups/#{group_id}")['projects']
+  rescue FourOhFour
+    raise NoSuchGroup, "No such group id: #{group_id}"
+  end
+
+  # @return [Array<Hash>] the remote JSON data
+  # @api private
+  def _tags_for_project_id(project_id)
+    get("projects/#{project_id}/repository/tags")
+  rescue FourOhFour
+    raise NoSuchProject, "No such project id: #{project_id}"
+  end
+
+  # @return [Hash] the remote JSON data
+  # @api private
+  def _file_for_project_id_and_path_and_ref(project_id, filepath, ref)
+    get("projects/#{project_id}/repository/files", file_path: filepath, ref: ref)
+  rescue FourOhFour
+    raise NoSuchFile, "No such file #{filepath} for project id #{project_id} and ref #{ref}"
+  end
+
+  # Retreive the remote JSON data.
+  #
+  # @param [String] url
+  #   The relative URL (must not have a leading '/')
+  # @param [Hash] query
+  #   The GET query. It will be URI encoded properly.
+  # @return [Faraday::Response]
+  def get(url, query = {})
+    fail "Programmer error: remove leading '/' from #{url}" if url.start_with?('/')
+
+    response = connection.get(url, query)
+    case response.status
+    when 200
+      JSON.load response.body
+    when 404
+      fail FourOhFour, "404 Error: #{url} #{query.inspect}"
+    else
+      fail Error, "Response failed #{response.inspect}"
+    end
+  rescue Errno::ETIMEDOUT
+    fail Error, "Server timed out: #{url} #{query.inspect}"
+  rescue Faraday::ConnectionFailed => err
+    fail Error, "Unable to connect to #{url}: #{err}"
+  end
+
+  private
+
+  # @return [Faraday]
+  def connection
+    @connection ||= Faraday.new(url: endpoint) do |faraday|
+      faraday.headers[:private_token] = private_token
+      faraday.headers[:accept] = 'application/json'
+      faraday.response :logger, @logger unless @logger.nil?
+      faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
+    end
+  end
+
+  # GitLab group API
+  class Group
+    attr_reader :client, :id, :path
+
+    # @param [GitlabClient] client
+    #   The client for this project
+    # @param [Hash] project_hash
+    #   The remote JSON data for a project.
+    def initialize(client, group_hash)
+      @client, @id, @path = client, group_hash['id'], group_hash['path']
+    end
+
+    # @return [Array<GitlabClient::Project>]
+    def projects
+      client._projects_for_group_id(id).map { |p| Project.new client, p }
+    end
+  end
+
+  # GitLab project API
+  class Project
+    attr_reader :client, :id, :path, :full_path, :web_url
+
+    # @param [GitlabClient] client
+    #   The client for this project
+    # @param [Hash] project_hash
+    #   The remote JSON data for a project.
+    def initialize(client, project_hash)
+      @client, @id, @path, @full_path, @web_url, @public = client,
+        project_hash['id'],
+        project_hash['path'],
+        project_hash['path_with_namespace'],
+        project_hash['web_url'],
+        project_hash['public']
+    end
+
+    # @return [Boolean] Is the repository public?
+    def public?
+      @public
+    end
+
+    # @return [Array<String>]
+    def tags
+      client._tags_for_project_id(id).map { |h| h['name'] }
+    rescue NoSuchProject
+      []
+    end
+
+    # @param [String] filepath
+    #   The path to the file relative to the root of the repository.
+    # @return [String] the contents of the file
+    def file(filepath, git_ref)
+      response = client._file_for_project_id_and_path_and_ref(id, filepath, git_ref)
+
+      case response['encoding']
+      when 'base64'
+        Base64.decode64(response['content'])
+      else
+        fail UnknownFileEncoding, "Unable to decode content with encoding #{response['encoding']}"
+      end
+    end
+  end
+end

--- a/spec/unit/berkshelf/api/cache_builder/worker/gitlab_spec.rb
+++ b/spec/unit/berkshelf/api/cache_builder/worker/gitlab_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+describe Berkshelf::API::CacheBuilder::Worker::Gitlab do
+  describe "ClassMethods" do
+    subject { described_class }
+    its(:worker_type) { should eql("gitlab") }
+  end
+
+  subject(:worker) do
+    expect(GitlabClient)
+      .to receive(:new) { connection }
+    described_class.new(group: group, url: url, private_token: token)
+  end
+
+  let(:connection) { double GitlabClient }
+  let(:group) { "group#{rand 99}" }
+  let(:url)   { "http://gitlab#{rand 9}.example.com/" }
+  let(:token) { "token#{rand 99}" }
+
+  it_behaves_like "a human-readable string"
+
+  describe "#cookbooks" do
+    let(:group_double)   { double GitlabClient::Group }
+    let(:project_double) { double GitlabClient::Project, id: project_id }
+    let(:project_id)     { rand 99 }
+    let(:good_tag)       { 'v1.2.3' }
+
+    # Connection
+    before do
+      expect(connection)
+        .to receive(:group)
+        .with(group)
+        .and_return(group_double)
+      expect(connection)
+        .to receive(:find_project_by_id)
+        .with(project_id)
+        .and_return(project_double)
+    end
+
+    # Group
+    before do
+      expect(group_double)
+        .to receive(:projects)
+        .and_return([project_double])
+    end
+
+    # Project
+    before do
+      expect(project_double)
+        .to receive(:public?)
+        .and_return(true)
+      expect(project_double)
+        .to receive(:tags)
+        .and_return([good_tag, 'bad-tag'])
+      allow(project_double)
+        .to receive(:full_path)
+        .and_return("full/path")
+      expect(project_double)
+        .to receive(:web_url)
+        .and_return('http:/example.com')
+      expect(project_double)
+        .to receive(:file)
+        .with('metadata.rb', good_tag)
+        .and_return("name 'some-cookbook'\nversion '#{good_tag[1..-1]}'")
+    end
+
+    it 'returns an array containing an item for each valid cookbook on the server' do
+      expect(subject.cookbooks).to have(1).items
+    end
+
+    it 'returns an array of RemoteCookbooks' do
+      subject.cookbooks.each do |cookbook|
+        expect(cookbook).to be_a(Berkshelf::API::RemoteCookbook)
+      end
+    end
+
+    it 'each RemoteCookbook is tagged with a location_type of :uri' do
+      subject.cookbooks.each do |cookbook|
+        expect(cookbook.location_type).to eql('uri')
+      end
+    end
+  end
+end

--- a/spec/unit/gitlab_client_spec.rb
+++ b/spec/unit/gitlab_client_spec.rb
@@ -1,0 +1,256 @@
+require 'spec_helper'
+require 'gitlab_client'
+
+describe GitlabClient do
+  subject(:client) { described_class.new(endpoint, private_token) }
+
+  let(:endpoint)      { "http://127.0.0.1:9999/gitlab#{rand 99}" }
+  let(:private_token) { "private-token-#{rand 9999}" }
+
+  describe '::new' do
+    its(:endpoint) { should eq(endpoint) }
+
+    its(:private_token) { should eq(private_token) }
+  end
+
+  context 'with a stubbed network' do
+    before do
+      allow(client)
+        .to receive(:connection)
+        .and_return(double(Faraday))
+    end
+
+    describe '.group' do
+      let(:group_path) { 'chef-cookbooks' }
+
+      before do
+        expect(client)
+          .to receive(:groups)
+          .and_return([double(GitlabClient::Group, path: group_path)])
+      end
+
+      it 'returns the group' do
+        expect(client.group(group_path).path)
+          .to eq(group_path)
+      end
+
+      it 'raises NoSuchGroup if missing' do
+        expect { client.group('no-such-group') }
+          .to raise_error(GitlabClient::NoSuchGroup)
+      end
+    end
+
+    describe '.groups' do
+      let(:group_hashes) { [double('group hash')] }
+
+      before do
+        expect(client)
+          .to receive(:get)
+          .with('groups')
+          .and_return(group_hashes)
+
+        allow(GitlabClient::Group)
+          .to receive(:new)
+      end
+
+      it 'calls Group.new for each response' do
+        group_hashes.each do |group_hash|
+          expect(GitlabClient::Group)
+            .to receive(:new)
+            .with(client, group_hash)
+        end
+
+        client.groups
+      end
+    end
+
+    describe '.find_project_by_id' do
+      let(:project_id) { rand 99 }
+      let(:response) { double 'get(projects/:id)' }
+
+      before do
+        expect(client)
+          .to receive(:get)
+          .with("projects/#{project_id}")
+          .and_return(response)
+
+        allow(GitlabClient::Project)
+          .to receive(:new)
+      end
+
+      it 'creates a Project' do
+        project = double
+        expect(GitlabClient::Project)
+          .to receive(:new)
+          .with(client, response)
+          .and_return(project)
+
+        expect(client.find_project_by_id project_id)
+          .to eq(project)
+      end
+    end
+
+    describe '._projects_for_group_id' do
+      context 'the group is invalid' do
+        before { allow(client).to receive(:get).and_raise(GitlabClient::FourOhFour) }
+
+        it 'raises NoSuchGroup' do
+          expect { client._projects_for_group_id 2 }
+            .to raise_error(GitlabClient::NoSuchGroup)
+        end
+      end
+    end
+
+    describe '._tags_for_project_id' do
+      context 'the project is invalid' do
+        before { allow(client).to receive(:get).and_raise(GitlabClient::FourOhFour) }
+
+        it 'raises NoSuchProject' do
+          expect { client._tags_for_project_id 2 }
+            .to raise_error(GitlabClient::NoSuchProject)
+        end
+      end
+    end
+
+    describe '._file_for_project_id_and_path_and_ref' do
+      context 'the project is invalid' do
+        before { allow(client).to receive(:get).and_raise(GitlabClient::FourOhFour) }
+
+        it 'raises NoSuchProject' do
+          expect { client._file_for_project_id_and_path_and_ref 2, '.rspec', 'master' }
+            .to raise_error(GitlabClient::NoSuchFile)
+        end
+      end
+    end
+  end
+end
+
+describe GitlabClient::Group do
+  subject(:group) { described_class.new(client, 'id' => id, 'path' => path) }
+
+  let(:client) { double GitlabClient, _projects_for_group_id: project_hashes }
+  let(:id) { rand 99 }
+  let(:path) { "group#{id}" }
+
+  its(:client)    { should eq(client) }
+  its(:id)        { should eq(id) }
+  its(:path)      { should eq(path) }
+
+  let(:project_hashes) do
+    (1..3).map do |i|
+      {
+        'id' => i,
+        'path' => "path#{i}",
+        'path_with_namespace' => "#{path}/path#{i}"
+      }
+    end
+  end
+
+  describe '.projects' do
+    it 'calls client._projects_for_group_id' do
+      expect(client)
+        .to receive(:_projects_for_group_id)
+        .with(id)
+
+      group.projects
+    end
+
+    it 'calls Project.new' do
+      project_hashes.each do |hash|
+        expect(GitlabClient::Project)
+          .to receive(:new)
+          .with(client, hash)
+      end
+
+      group.projects
+    end
+  end
+end
+
+describe GitlabClient::Project do
+  subject(:project) do
+    described_class.new(client,
+                        'id' => id,
+                        'path' => path,
+                        'path_with_namespace' => full_path,
+                        'web_url' => web_url,
+                        'public' => is_public)
+  end
+
+  let(:client)    { double GitlabClient, _tags_for_project_id: tag_hashes }
+  let(:id)        { rand 99 }
+  let(:path)      { "project#{id}" }
+  let(:full_path) { "group/#{path}" }
+  let(:web_url)   { "http://gitlab.example.com/#{full_path}" }
+  let(:is_public)    { rand(2) == 1 }
+
+  let(:tag_hashes) do
+    (1..2).map do |i|
+      { 'name' => "name#{i}" }
+    end
+  end
+
+  its(:client)    { should eq(client) }
+  its(:id)        { should eq(id) }
+  its(:path)      { should eq(path) }
+  its(:full_path) { should eq(full_path) }
+  its(:web_url)   { should eq(web_url) }
+  its(:public?)   { should eq(is_public) }
+
+  describe '.tags' do
+    it 'calls client._tags_for_project_id' do
+      expect(client)
+        .to receive(:_tags_for_project_id)
+        .with(id)
+        .and_return(tag_hashes)
+
+      project.tags
+    end
+
+    it 'gets the name of each tag' do
+      tag_hashes.each do |tag_hash|
+        expect(tag_hash)
+          .to receive(:[])
+          .with('name')
+      end
+
+      project.tags
+    end
+
+    its(:tags) { should match_array(tag_hashes.map{|th| th['name']}) }
+  end
+
+  describe '.file' do
+    let(:ref) { "v#{rand 99}" }
+    let(:filename) { "lib/file{#rand 99}.rb" }
+    let(:file_response) do
+      {
+        'encoding' => 'base64',
+        'content' => "QmUgc3VyZSB0byBkcmluayB5b3VyIE92YWx0aW5l\n"
+      }
+    end
+
+    before do
+      expect(client)
+        .to receive(:_file_for_project_id_and_path_and_ref)
+        .with(id, filename, ref)
+        .and_return(file_response)
+    end
+
+    it 'decodes the response' do
+      expect(project.file(filename, ref))
+        .to eq('Be sure to drink your Ovaltine')
+    end
+
+    context 'with an unknown encoding' do
+      let(:file_response) do
+        { 'encoding' => 'fubar' }
+      end
+
+      it 'raises an UnknownFileEncoding error' do
+        expect { project.file(filename, ref) }
+          .to raise_error(GitlabClient::UnknownFileEncoding)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows berks-api to scan GitLab repositories and index
them if they public.

It requires the :uri downloader in berkshelf v3.0.0beta8 or newer.

Closes #84
