### PR TITLE
Switch to HOME environment variable instead of ~ for populating default home_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Ruby 1.9.1 and 1.9.2 are not officially supported. If you encounter problems, pl
 
 ## Configuring Endpoints
 
-You may configure the endpoints to index by editing the JSON configuration file (default: `~/.berkshelf/api-server/config.json`).
+You may configure the endpoints to index by editing the JSON configuration file (default: `#{ENV['HOME']}/.berkshelf/api-server/config.json`).
 
 ### Opscode Community Site
 

--- a/lib/berkshelf/api/config.rb
+++ b/lib/berkshelf/api/config.rb
@@ -6,14 +6,14 @@ module Berkshelf::API
     class << self
       # @return [String]
       def default_path
-        home_path = ENV['BERKSHELF_API_PATH'] || "~/.berkshelf/api-server"
+        home_path = ENV['BERKSHELF_API_PATH'] || "#{ENV['HOME']}/.berkshelf/api-server"
         File.expand_path(File.join(home_path, "config.json"))
       end
     end
 
     attribute 'home_path',
       type: String,
-      default: File.expand_path("~/.berkshelf/api-server")
+      default: File.expand_path("#{ENV['HOME']}/.berkshelf/api-server")
 
     attribute 'endpoints',
       type: Array,


### PR DESCRIPTION
When ~ cannot be resolved it throws an exception which stops execution, even if you've completely overridden the default value:

/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/berkshelf-api-1.1.1/lib/berkshelf/api/config.rb:16:in `expand_path': couldn't find HOME environment -- expanding`~' (ArgumentError)

When ENV['HOME'] is undefined it fails silently.  I'm not sure that this is necessarily ideal, but it allows the app to run under runit (as used in the berkshelf cookbook).
