### PR TITLE
Bump version of Faraday 0.9.0.

### DIFF
--- a/berkshelf-api.gemspec
+++ b/berkshelf-api.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 1.9.3"
 
-  spec.add_dependency 'ridley', '~> 2.0'
+  spec.add_dependency 'ridley', '~> 2.6'
   spec.add_dependency 'celluloid', '~> 0.15'
   spec.add_dependency 'reel', '>= 0.4.0'
   spec.add_dependency 'grape', '~> 0.6'
   spec.add_dependency 'grape-msgpack', '~> 0.1'
   spec.add_dependency 'hashie', '>= 2.0.4'
-  spec.add_dependency 'faraday', '~> 0.8.0'
+  spec.add_dependency 'faraday', '~> 0.9.0'
   spec.add_dependency 'retryable', '~> 1.3.3'
   spec.add_dependency 'archive', '= 0.0.5'
   spec.add_dependency 'buff-config', '~> 0.1'


### PR DESCRIPTION
This is a dependency update which will bring several projects to the
latest version of Faraday. I have put in pull-requests to the
berkshelf and ridley gems for this as well.

Here's to hoping that no_proxy (environment) support will be merged into
Faraday 0.9.0 branch soon so that all of us poor schmucks in the
enterprise can rejoice.
