### PR TITLE
LoadError: cannot load such file -- http/headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'berkshelf', github: "berkshelf/berkshelf"
   gem 'berkflow', github: "reset/berkflow"
   gem 'thor',      '~> 0.18'
   gem 'chef-zero', '~> 1.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,9 @@
 GIT
-  remote: git://github.com/berkshelf/berkshelf.git
-  revision: eabb03a7a87f3ffa19bd1024ce7b71e4ade792db
-  specs:
-    berkshelf (3.0.0.rc1)
-      addressable (~> 2.3.4)
-      berkshelf-api-client (~> 1.2.0.rc2)
-      buff-config (~> 0.2)
-      buff-extensions (~> 0.4)
-      buff-shell_out (~> 0.1)
-      faraday (~> 0.9.0)
-      minitar (~> 0.5.4)
-      octokit (~> 2.6)
-      retryable (~> 1.3.3)
-      ridley (~> 3.0)
-      solve (~> 1.0.0.rc3)
-      thor (~> 0.18)
-
-GIT
   remote: git://github.com/reset/berkflow.git
-  revision: c414473fb60d49529e819f78cd58375bc5ebdb20
+  revision: 930549138f041c68a4f6a1f6bc37e0c08a498e90
   specs:
-    berkflow (0.3.0)
-      berkshelf (~> 3.0.0.rc1)
+    berkflow (0.4.0)
+      berkshelf (~> 3.0)
       octokit (~> 2.6)
       ridley (~> 3.0)
       ridley-connectors (~> 2.0)
@@ -39,9 +21,8 @@ PATH
       grape (~> 0.6)
       grape-msgpack (~> 0.1)
       hashie (>= 2.0.4)
-      http (~> 0.5.0)
       octokit (~> 2.6)
-      reel (>= 0.4.0)
+      reel (~> 0.5.0)
       retryable (~> 1.3.3)
       ridley (~> 3.0)
       semverse (~> 1.0)
@@ -65,7 +46,22 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    berkshelf-api-client (1.2.0.rc2)
+    berkshelf (3.0.1)
+      addressable (~> 2.3.4)
+      berkshelf-api-client (~> 1.2)
+      buff-config (~> 0.2)
+      buff-extensions (~> 0.4)
+      buff-shell_out (~> 0.1)
+      celluloid (~> 0.16.0.pre)
+      celluloid-io (~> 0.16.0.pre)
+      faraday (~> 0.9.0)
+      minitar (~> 0.5.4)
+      octokit (~> 2.6)
+      retryable (~> 1.3.3)
+      ridley (~> 3.0)
+      solve (~> 1.1)
+      thor (~> 0.18)
+    berkshelf-api-client (1.2.0)
       faraday (~> 0.9.0)
     buff-config (0.4.0)
       buff-extensions (~> 0.3)
@@ -93,9 +89,9 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     coolline (0.4.3)
-    dep-selector-libgecode (1.0.0.rc.1)
-    dep_selector (1.0.0.rc.1)
-      dep-selector-libgecode (~> 1.0.0.rc)
+    dep-selector-libgecode (1.0.0)
+    dep_selector (1.0.2)
+      dep-selector-libgecode (~> 1.0)
       ffi (~> 1.9)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -139,10 +135,10 @@ GEM
       spork (>= 0.8.4)
     gyoku (1.1.1)
       builder (>= 2.1.2)
-    hashie (2.1.0)
+    hashie (2.1.1)
     hitimes (1.2.1)
-    http (0.5.0)
-      http_parser.rb
+    http (0.6.0)
+      http_parser.rb (~> 0.6.0)
     http_parser.rb (0.6.0)
     httpclient (2.3.4.1)
     httpi (0.9.7)
@@ -162,7 +158,7 @@ GEM
     method_source (0.8.2)
     mini_portile (0.5.3)
     minitar (0.5.4)
-    minitest (5.3.2)
+    minitest (5.3.3)
     mixlib-authentication (1.3.0)
       mixlib-log
     mixlib-log (1.6.0)
@@ -196,12 +192,12 @@ GEM
     rb-kqueue (0.2.2)
       ffi (>= 0.5.0)
     redcarpet (3.1.1)
-    reel (0.4.0)
+    reel (0.5.0)
       celluloid (>= 0.15.1)
       celluloid-io (>= 0.15.0)
-      http (>= 0.5.0)
-      http_parser.rb (>= 0.6.0.beta.2)
-      websocket_parser (>= 0.1.4)
+      http (>= 0.6.0.pre)
+      http_parser.rb (>= 0.6.0)
+      websocket_parser (>= 0.1.6)
     retryable (1.3.5)
     ridley (3.0.0)
       addressable
@@ -249,8 +245,8 @@ GEM
       faraday (~> 0.8, < 0.10)
     semverse (1.1.0)
     slop (3.5.0)
-    solve (1.0.0.rc3)
-      dep_selector (~> 1.0.0.rc)
+    solve (1.1.0)
+      dep_selector (~> 1.0)
       semverse (~> 1.1)
     spork (0.9.2)
     thor (0.19.1)
@@ -286,7 +282,6 @@ PLATFORMS
 
 DEPENDENCIES
   berkflow!
-  berkshelf!
   berkshelf-api!
   chef-zero (~> 1.5)
   coolline

--- a/berkshelf-api.gemspec
+++ b/berkshelf-api.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'ridley',         '~> 3.0'
   spec.add_dependency 'celluloid',      '~> 0.16.0.pre'
-  spec.add_dependency 'reel',           '>= 0.4.0'
-  spec.add_dependency 'http',           '~> 0.5.0' # explicitly lock because reel's is too lax
+  spec.add_dependency 'reel',           '~> 0.5.0'
   spec.add_dependency 'grape',          '~> 0.6'
   spec.add_dependency 'grape-msgpack',  '~> 0.1'
   spec.add_dependency 'hashie',         '>= 2.0.4'

--- a/lib/berkshelf/api/rest_gateway.rb
+++ b/lib/berkshelf/api/rest_gateway.rb
@@ -1,7 +1,7 @@
 require 'reel'
 
 module Berkshelf::API
-  class RESTGateway < Reel::Server
+  class RESTGateway < Reel::Server::HTTP
     extend Forwardable
     include Berkshelf::API::GenericServer
     include Berkshelf::API::Logging


### PR DESCRIPTION
After installing `berkshelf-api` from the gem I'm receiving `LoadError: cannot load such file -- http/headers`. Here's the full log:

```
$ rvm use 2.0.0
Using /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451


$ rvm gemset create berks-api && rvm gemset use berks-api
ruby-2.0.0-p451 - #gemset created /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api
ruby-2.0.0-p451 - #generating berks-api wrappers.........
Using ruby-2.0.0-p451 with gemset berks-api


$ gem install berkshelf-api
Fetching: semverse-1.1.0.gem (100%)
Successfully installed semverse-1.1.0
Fetching: retryable-1.3.5.gem (100%)
Successfully installed retryable-1.3.5
Fetching: net-http-persistent-2.9.4.gem (100%)
Successfully installed net-http-persistent-2.9.4
Fetching: mixlib-log-1.6.0.gem (100%)
Successfully installed mixlib-log-1.6.0
Fetching: mixlib-authentication-1.3.0.gem (100%)
Successfully installed mixlib-authentication-1.3.0
Fetching: hashie-2.1.1.gem (100%)
Successfully installed hashie-2.1.1
Fetching: multipart-post-2.0.0.gem (100%)
Successfully installed multipart-post-2.0.0
Fetching: faraday-0.9.0.gem (100%)
Successfully installed faraday-0.9.0
Fetching: erubis-2.7.0.gem (100%)
Successfully installed erubis-2.7.0
Fetching: nio4r-1.0.0.gem (100%)
Building native extensions.  This could take a while...
Successfully installed nio4r-1.0.0
Fetching: hitimes-1.2.1.gem (100%)
Building native extensions.  This could take a while...
Successfully installed hitimes-1.2.1
Fetching: timers-2.0.0.gem (100%)
Successfully installed timers-2.0.0
Fetching: celluloid-0.16.0.pre.gem (100%)
Successfully installed celluloid-0.16.0.pre
Fetching: celluloid-io-0.16.0.pre.gem (100%)
Successfully installed celluloid-io-0.16.0.pre
Fetching: buff-ruby_engine-0.1.0.gem (100%)
Successfully installed buff-ruby_engine-0.1.0
Fetching: buff-shell_out-0.1.1.gem (100%)
Successfully installed buff-shell_out-0.1.1
Fetching: buff-ignore-1.1.1.gem (100%)
Successfully installed buff-ignore-1.1.1
Fetching: buff-extensions-0.5.0.gem (100%)
Successfully installed buff-extensions-0.5.0
Fetching: varia_model-0.3.2.gem (100%)
Successfully installed varia_model-0.3.2
Fetching: buff-config-0.4.0.gem (100%)
Successfully installed buff-config-0.4.0
Fetching: addressable-2.3.6.gem (100%)
Successfully installed addressable-2.3.6
Fetching: ridley-3.0.0.gem (100%)
Successfully installed ridley-3.0.0
Fetching: websocket_parser-0.1.6.gem (100%)
Successfully installed websocket_parser-0.1.6
Fetching: http_parser.rb-0.6.0.gem (100%)
Building native extensions.  This could take a while...
Successfully installed http_parser.rb-0.6.0
Fetching: http-0.5.0.gem (100%)
Successfully installed http-0.5.0
Fetching: reel-0.5.0.pre.gem (100%)
Successfully installed reel-0.5.0.pre
Fetching: builder-3.2.2.gem (100%)
Successfully installed builder-3.2.2
Fetching: thread_safe-0.3.3.gem (100%)
Successfully installed thread_safe-0.3.3
Fetching: ice_nine-0.11.0.gem (100%)
Successfully installed ice_nine-0.11.0
Fetching: descendants_tracker-0.0.4.gem (100%)
Successfully installed descendants_tracker-0.0.4
Fetching: axiom-types-0.1.1.gem (100%)
Successfully installed axiom-types-0.1.1
Fetching: coercible-1.0.0.gem (100%)
Successfully installed coercible-1.0.0
Fetching: equalizer-0.0.9.gem (100%)
Successfully installed equalizer-0.0.9
Fetching: virtus-1.0.2.gem (100%)
Successfully installed virtus-1.0.2
Fetching: multi_xml-0.5.5.gem (100%)
Successfully installed multi_xml-0.5.5
Fetching: multi_json-1.9.2.gem (100%)
Successfully installed multi_json-1.9.2
Fetching: minitest-5.3.3.gem (100%)
Successfully installed minitest-5.3.3
Fetching: tzinfo-1.1.0.gem (100%)
Successfully installed tzinfo-1.1.0
Fetching: i18n-0.6.9.gem (100%)
Successfully installed i18n-0.6.9
Fetching: activesupport-4.1.0.gem (100%)
Successfully installed activesupport-4.1.0
Fetching: rack-1.5.2.gem (100%)
Successfully installed rack-1.5.2
Fetching: rack-accept-0.4.5.gem (100%)
Successfully installed rack-accept-0.4.5
Fetching: rack-mount-0.8.3.gem (100%)
Successfully installed rack-mount-0.8.3
Fetching: grape-0.7.0.gem (100%)
Successfully installed grape-0.7.0
Fetching: msgpack-0.5.8.gem (100%)
Building native extensions.  This could take a while...
Successfully installed msgpack-0.5.8
Fetching: grape-msgpack-0.1.1.gem (100%)
Successfully installed grape-msgpack-0.1.1
Fetching: ffi-1.9.3.gem (100%)
Building native extensions.  This could take a while...
Successfully installed ffi-1.9.3
Fetching: archive-0.0.6.gem (100%)
Successfully installed archive-0.0.6
Fetching: sawyer-0.5.4.gem (100%)
Successfully installed sawyer-0.5.4
Fetching: octokit-2.7.2.gem (100%)
Successfully installed octokit-2.7.2
Fetching: berkshelf-api-1.2.1.gem (100%)
Successfully installed berkshelf-api-1.2.1
51 gems installed


$ berks-api -v -d
I, [2014-04-17T13:39:54.080713 #43007]  INFO -- : Cache manager starting...
I, [2014-04-17T13:39:54.100454 #43007]  INFO -- : Cache Builder starting...
E, [2014-04-17T13:39:54.212524 #43007] ERROR -- : Actor crashed!
LoadError: cannot load such file -- http/headers
    /Users/benlemasurier/.rvm/rubies/ruby-2.0.0-p451/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    /Users/benlemasurier/.rvm/rubies/ruby-2.0.0-p451/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/reel-0.5.0.pre/lib/reel/response.rb:1:in `<top (required)>'
    /Users/benlemasurier/.rvm/rubies/ruby-2.0.0-p451/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    /Users/benlemasurier/.rvm/rubies/ruby-2.0.0-p451/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/reel-0.5.0.pre/lib/reel.rb:12:in `<top (required)>'
    /Users/benlemasurier/.rvm/rubies/ruby-2.0.0-p451/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    /Users/benlemasurier/.rvm/rubies/ruby-2.0.0-p451/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/berkshelf-api-1.2.1/lib/berkshelf/api/rest_gateway.rb:1:in `<top (required)>'
    /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/berkshelf-api-1.2.1/lib/berkshelf/api/application.rb:19:in `require_relative'
    /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/berkshelf-api-1.2.1/lib/berkshelf/api/application.rb:19:in `initialize'
    /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/calls.rb:26:in `public_send'
    /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/calls.rb:26:in `dispatch'
    /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/calls.rb:63:in `dispatch'
    /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/cell.rb:60:in `block in invoke'
    /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/cell.rb:71:in `block in task'
    /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/actor.rb:362:in `block in task'
    /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/tasks.rb:55:in `block in initialize'
    /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/tasks/task_fiber.rb:15:in `block in create'
D, [2014-04-17T13:39:54.212836 #43007] DEBUG -- : Terminating 34 actors...
I, [2014-04-17T13:39:54.213713 #43007]  INFO -- : Cache Builder shutting down...
I, [2014-04-17T13:39:54.213947 #43007]  INFO -- : Cache Manager shutting down...
W, [2014-04-17T13:39:54.233285 #43007]  WARN -- : Terminating task: type=:finalizer, meta={:method_name=>:__shutdown__}, status=:callwait
    Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2014-04-17T13:39:54.234946 #43007]  WARN -- : Terminating task: type=:finalizer, meta={:method_name=>:__shutdown__}, status=:callwait
    Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2014-04-17T13:39:54.235294 #43007]  WARN -- : Terminating task: type=:finalizer, meta={:method_name=>:__shutdown__}, status=:callwait
    Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
/Users/benlemasurier/.rvm/rubies/ruby-2.0.0-p451/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- http/headers (LoadError)
    from /Users/benlemasurier/.rvm/rubies/ruby-2.0.0-p451/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/reel-0.5.0.pre/lib/reel/response.rb:1:in `<top (required)>'
    from /Users/benlemasurier/.rvm/rubies/ruby-2.0.0-p451/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/benlemasurier/.rvm/rubies/ruby-2.0.0-p451/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/reel-0.5.0.pre/lib/reel.rb:12:in `<top (required)>'
    from /Users/benlemasurier/.rvm/rubies/ruby-2.0.0-p451/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/benlemasurier/.rvm/rubies/ruby-2.0.0-p451/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/berkshelf-api-1.2.1/lib/berkshelf/api/rest_gateway.rb:1:in `<top (required)>'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/berkshelf-api-1.2.1/lib/berkshelf/api/application.rb:19:in `require_relative'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/berkshelf-api-1.2.1/lib/berkshelf/api/application.rb:19:in `initialize'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/calls.rb:26:in `public_send'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/calls.rb:26:in `dispatch'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/calls.rb:63:in `dispatch'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/cell.rb:60:in `block in invoke'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/cell.rb:71:in `block in task'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/actor.rb:362:in `block in task'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/tasks.rb:55:in `block in initialize'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/tasks/task_fiber.rb:15:in `block in create'
    from (celluloid):0:in `remote procedure call'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/calls.rb:92:in `value'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/proxies/sync_proxy.rb:33:in `method_missing'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid/proxies/cell_proxy.rb:17:in `_send_'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/celluloid-0.16.0.pre/lib/celluloid.rb:169:in `new'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/berkshelf-api-1.2.1/lib/berkshelf/api/application.rb:143:in `run!'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/berkshelf-api-1.2.1/lib/berkshelf/api/application.rb:119:in `block in run'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/berkshelf-api-1.2.1/lib/berkshelf/api/application.rb:118:in `loop'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/berkshelf-api-1.2.1/lib/berkshelf/api/application.rb:118:in `run'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/berkshelf-api-1.2.1/lib/berkshelf/api/srv_ctl.rb:63:in `start'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/berkshelf-api-1.2.1/lib/berkshelf/api/srv_ctl.rb:48:in `run'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/gems/berkshelf-api-1.2.1/bin/berks-api:5:in `<top (required)>'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/bin/berks-api:23:in `load'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/bin/berks-api:23:in `<main>'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/bin/ruby_executable_hooks:15:in `eval'
    from /Users/benlemasurier/.rvm/gems/ruby-2.0.0-p451@berks-api/bin/ruby_executable_hooks:15:in `<main>'
```
