### PR TITLE
Return JSON to naive HTTP clients like browsers or curl.

### DIFF
--- a/lib/berkshelf/api/endpoint.rb
+++ b/lib/berkshelf/api/endpoint.rb
@@ -7,6 +7,8 @@ module Berkshelf::API
       # Force inbound requests to be JSON
       def call(env)
         env['CONTENT_TYPE'] = 'application/json'
+        # If coming from a browser or other naive HTTP client, we want JSON back
+        env['HTTP_ACCEPT'] = 'application/json' if !env['HTTP_ACCEPT'] || env['HTTP_ACCEPT'].include?('text/html')
         super
       end
     end


### PR DESCRIPTION
Looks like this broke after https://github.com/berkshelf/berkshelf-api/commit/5fec073f5131bde75ad44128001cbfcdc3c62baa switch from `format` to `default_format`, which checks the Accept header to determine what format to use. Thanks to XHTML, most browsers and similar clients include `application/xml` in their types list. Not sure if this is too heavy a hammer, but it does seem to work.
