### PR TITLE
Fixing logic error in app recipe

### DIFF
--- a/cookbook/Berksfile.lock
+++ b/cookbook/Berksfile.lock
@@ -12,7 +12,7 @@ GRAPH
     runit (>= 0.0.0)
   bluepill (2.3.1)
     rsyslog (>= 0.0.0)
-  build-essential (2.0.0)
+  build-essential (2.0.2)
   github (0.2.1)
     libarchive (>= 0.0.0)
   libarchive (0.4.0)

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -4,6 +4,8 @@ Installs/Configures a berkshelf-api server
 
 ## Supported Platforms
 
+  * Redhat
+  * CentOS
   * Ubuntu
 
 ## Attributes

--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -10,9 +10,12 @@ description      "Installs/Configures a berkshelf-api server"
 long_description "Installs/Configures a berkshelf-api server"
 version          Berkshelf::API::VERSION
 
-supports "ubuntu"
+%w{ redhat centos ubuntu }.each do |os|
+  supports os
+end
 
 depends "runit"
+depends "build-essential", ">= 2.0.2"
 depends "nginx",           ">= 1.7.0"
 depends "libarchive",      "~> 0.4"
 depends "github",          "~> 0.2"

--- a/cookbook/recipes/app.rb
+++ b/cookbook/recipes/app.rb
@@ -22,17 +22,17 @@ include_recipe "runit"
 
 chef_gem "bundler"
 
-user node[:berkshelf_api][:owner] do
-  home node[:berkshelf_api][:home]
-end
-
-group node[:berkshelf_api][:group]
-
 directory node[:berkshelf_api][:home] do
   owner node[:berkshelf_api][:owner]
   group node[:berkshelf_api][:group]
   recursive true
 end
+
+user node[:berkshelf_api][:owner] do
+  home node[:berkshelf_api][:home]
+end
+
+group node[:berkshelf_api][:group]
 
 file node[:berkshelf_api][:config_path] do
   content JSON.generate(node[:berkshelf_api][:config].to_hash)


### PR DESCRIPTION
If the dir node[:berkshelf_api][:home] is not there when creating the
user (which uses node[:berkshelf_api][:home] as it’s homedir), useradd
fails and breaks the CCR
