### PR TITLE
Update srv_ctl.rb

### DIFF
--- a/lib/berkshelf/api/srv_ctl.rb
+++ b/lib/berkshelf/api/srv_ctl.rb
@@ -12,6 +12,10 @@ module Berkshelf
           options = Hash.new
 
           OptionParser.new("Usage: #{filename} [options]") do |opts|
+            opts.on("-h", "--host HOST", String, "set the listening address") do |h|
+              options[:host] = h
+            end
+            
             opts.on("-p", "--port PORT", Integer, "set the listening port") do |v|
               options[:port] = v
             end


### PR DESCRIPTION
Added host option processing. To restrict berlshelf-api listening only on one address.
