### PR TITLE
Updated the call to the user provider so it creates a system user

### DIFF
--- a/cookbook/recipes/app.rb
+++ b/cookbook/recipes/app.rb
@@ -30,6 +30,7 @@ end
 
 user node[:berkshelf_api][:owner] do
   home node[:berkshelf_api][:home]
+  system true
 end
 
 group node[:berkshelf_api][:group]


### PR DESCRIPTION
By adding ‘system true’ to the call, this user will now be created with
‘useradd -r’ which makes the user have a low UID (usually below 500)
and treads this used as a system user.

We need this because currently this new user interferes with our internal user management. If this is an absolutely unacceptable change, then I can of course also rework the patch so this becomes a configurable option instead.

But since this is in fact a system user meant for running the berks-api, I guess this would be OK...?

S. 
