### PR TITLE
Fixed host attribute documentation in README.md

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -67,7 +67,7 @@ Installs/Configures a berkshelf-api server
   </tr>
   <tr>
     <td><tt>[:berkshelf_api][:host]</tt></td>
-    <td>Integer</td>
+    <td>String</td>
     <td>Proxy's hostname</td>
     <td><tt>{fqdn}</tt></td>
   </tr>


### PR DESCRIPTION
The host attribute is documented as integer instead of string.
