### PR TITLE
Try to be defensive about failed community site calls

### DIFF
--- a/lib/berkshelf/api/site_connector/opscode.rb
+++ b/lib/berkshelf/api/site_connector/opscode.rb
@@ -60,9 +60,15 @@ module Berkshelf::API
         cookbooks = Array.new
 
         while count > 0
-          cookbooks += connection.get("cookbooks?start=#{start}&items=#{count}").body["items"]
-          start += 100
-          count -= 100
+          req = connection.get("cookbooks?start=#{start}&items=#{count}")
+          chunk = req.body["items"]
+          if chunk
+            cookbooks += chunk
+            start += 100
+            count -= 100
+          else
+            log.warn "Didn't get any cookbooks - #{req.body}"
+          end
         end
 
         cookbooks.map { |cb| cb["cookbook_name"] }


### PR DESCRIPTION
Since the main server runs in heroku it doesn't keep a cache, so a crash is 
VERY expensive. Sometimes the cookbooks get is returning an empty body (or at
least body['items'] is nil) so let's try and avoid that.
