### PR TITLE
switch default of "opscode" to use supermarket

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You may configure the endpoints to index by editing the JSON configuration file 
     {
       "type": "opscode",
       "options": {
-        "url": "http://cookbooks.opscode.com/api/v1"
+        "url": "https://supermarket.getchef.com/api/v1"
       }
     }
   ]

--- a/lib/berkshelf/api/config.rb
+++ b/lib/berkshelf/api/config.rb
@@ -21,7 +21,7 @@ module Berkshelf::API
         {
           type: "opscode",
           options: {
-            url: 'http://cookbooks.opscode.com/api/v1'
+            url: 'https://supermarket.getchef.com/api/v1'
           }
         }
       ]

--- a/lib/berkshelf/api/site_connector/opscode.rb
+++ b/lib/berkshelf/api/site_connector/opscode.rb
@@ -25,7 +25,7 @@ module Berkshelf::API
       include Celluloid
       include Berkshelf::API::Logging
 
-      V1_API = 'http://cookbooks.opscode.com/api/v1'.freeze
+      V1_API = 'https://supermarket.getchef.com/api/v1'.freeze
 
       # @return [String]
       attr_reader :api_uri

--- a/spec/unit/berkshelf/api/config_spec.rb
+++ b/spec/unit/berkshelf/api/config_spec.rb
@@ -18,7 +18,7 @@ describe Berkshelf::API::Config do
 
     it "has the Opscode community site as an endpoint" do
       expect(subject.endpoints.first.type).to eql("opscode")
-      expect(subject.endpoints.first.options[:url]).to eql("http://cookbooks.opscode.com/api/v1")
+      expect(subject.endpoints.first.options[:url]).to eql("https://supermarket.getchef.com/api/v1")
     end
   end
 end

--- a/spec/unit/berkshelf/api/site_connector/opscode_spec.rb
+++ b/spec/unit/berkshelf/api/site_connector/opscode_spec.rb
@@ -52,7 +52,7 @@ describe Berkshelf::API::SiteConnector::Opscode do
     let(:result) { subject.find(name, version) }
 
     it "returns the cookbook and version information" do
-      expect(result.cookbook).to eq('http://cookbooks.opscode.com/api/v1/cookbooks/nginx')
+      expect(result.cookbook).to eq('https://supermarket.getchef.com/api/v1/cookbooks/nginx')
       expect(result.version).to eq('1.4.0')
     end
 


### PR DESCRIPTION
The "opscode" site type currently points at cookbooks.opscode.com.
However, it should point at supermarket.getchef.com, and further, it
should use https
