### PR TITLE
Build cache Interval paremeterized 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ And add your configuration to the `node[:berkshelf_api][:config]` attribute
         }
       ]
     },
-    "host":"your.fqdn.here"
+    "host":"your.fqdn.here",
+    "refresh_interval":5.0
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ And add your configuration to the `node[:berkshelf_api][:config]` attribute
           }
         }
       ],
-      "refresh_interval":5.0
+      "build_interval":5.0
 
     },
     "host":"your.fqdn.here"
@@ -64,6 +64,8 @@ And add your configuration to the `node[:berkshelf_api][:config]` attribute
   }
 }
 ```
+ Explanation of some optional attributes
+  - build_interval : The number of seconds before it refreshes from the endpoints.
 
 > See configuration endpoints below for a complete list of supported endpoints, and the [api cookbook readme](https://github.com/berkshelf/berkshelf-api/tree/master/cookbook) for all configuration options.
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ And add your configuration to the `node[:berkshelf_api][:config]` attribute
             "client_name": "berkshelf"
           }
         }
-      ]
+      ],
+      "refresh_interval":5.0
+
     },
-    "host":"your.fqdn.here",
-    "refresh_interval":5.0
+    "host":"your.fqdn.here"
+
   }
 }
 ```

--- a/lib/berkshelf/api/cache_builder.rb
+++ b/lib/berkshelf/api/cache_builder.rb
@@ -19,9 +19,9 @@ module Berkshelf::API
       @worker_registry   = Celluloid::Registry.new
       @worker_supervisor = WorkerSupervisor.new(@worker_registry)
       @building          = false
-      @build_interval   = Application.config.refresh_interval
+      @build_interval   = Application.config.build_interval
 
-      log.info "Cache Builder refresh interval: #{@build_interval}"
+      log.info "Cache Builder build interval: #{@build_interval}"
 
       Application.config.endpoints.each_with_index do |endpoint, index|
         endpoint_options = (endpoint.options || {}).to_hash.deep_symbolize_keys

--- a/lib/berkshelf/api/cache_builder.rb
+++ b/lib/berkshelf/api/cache_builder.rb
@@ -4,7 +4,7 @@ module Berkshelf::API
 
     class WorkerSupervisor < Celluloid::SupervisionGroup; end
 
-    BUILD_INTERVAL = 5.0
+    
 
     include Berkshelf::API::GenericServer
     include Berkshelf::API::Logging
@@ -13,11 +13,15 @@ module Berkshelf::API
     server_name :cache_builder
     finalizer :finalize_callback
 
+
     def initialize
       log.info "Cache Builder starting..."
       @worker_registry   = Celluloid::Registry.new
       @worker_supervisor = WorkerSupervisor.new(@worker_registry)
       @building          = false
+      @build_interval   = Application.config.refresh_interval
+
+      log.info "Cache Builder refresh interval: #{@build_interval}"
 
       Application.config.endpoints.each_with_index do |endpoint, index|
         endpoint_options = (endpoint.options || {}).to_hash.deep_symbolize_keys
@@ -32,7 +36,7 @@ module Berkshelf::API
     # Issue a build command to all workers at the scheduled interval
     #
     # @param [Fixnum, Float] interval
-    def build_loop(interval = BUILD_INTERVAL)
+    def build_loop(interval = @build_interval)
       return if @building
 
       loop do

--- a/lib/berkshelf/api/config.rb
+++ b/lib/berkshelf/api/config.rb
@@ -23,7 +23,7 @@ module Berkshelf::API
         }
       ]
 
-    attribute 'refresh_interval',
+    attribute 'build_interval',
       type:Float,
       default:5.0
 

--- a/lib/berkshelf/api/config.rb
+++ b/lib/berkshelf/api/config.rb
@@ -23,6 +23,10 @@ module Berkshelf::API
         }
       ]
 
+    attribute 'refresh_interval',
+      type:Float,
+      default:5.0
+
     def endpoints_checksum
       Digest::SHA1.hexdigest(endpoints.collect {|x| x.to_hash }.to_s)
     end

--- a/spec/unit/berkshelf/api/config_spec.rb
+++ b/spec/unit/berkshelf/api/config_spec.rb
@@ -20,8 +20,8 @@ describe Berkshelf::API::Config do
       expect(subject.endpoints.first.type).to eql("supermarket")
     end
 
-    it "has the default refresh_interval" do
-      expect(subject.refresh_interval).to eq(5.0)
+    it "has the default build_interval" do
+      expect(subject.build_interval).to eq(5.0)
     end
   end
 end

--- a/spec/unit/berkshelf/api/config_spec.rb
+++ b/spec/unit/berkshelf/api/config_spec.rb
@@ -19,5 +19,9 @@ describe Berkshelf::API::Config do
     it "has the Supermarket community site as an endpoint" do
       expect(subject.endpoints.first.type).to eql("supermarket")
     end
+
+    it "has the default refresh_interval" do
+      expect(subject.refresh_interval).to eq(5.0)
+    end
   end
 end


### PR DESCRIPTION
Allows users to configure the interval at which the endpoints are refreshed.  Defaults to the current standard of 5.0 and updated documentation for examples.

fixes #155 
