### PR TITLE
Use provided group when creating user

### DIFF
--- a/cookbook/recipes/app.rb
+++ b/cookbook/recipes/app.rb
@@ -23,6 +23,7 @@ include_recipe "runit"
 chef_gem "bundler"
 
 user node[:berkshelf_api][:owner] do
+  gid node[:berkshelf_api][:group]
   home node[:berkshelf_api][:home]
   system true
 end

--- a/cookbook/recipes/app.rb
+++ b/cookbook/recipes/app.rb
@@ -22,6 +22,10 @@ include_recipe "runit"
 
 chef_gem "bundler"
 
+unless node[:berkshelf_api][:group] == node[:berkshelf_api][:owner]
+  group node[:berkshelf_api][:group]
+end
+
 user node[:berkshelf_api][:owner] do
   gid node[:berkshelf_api][:group]
   home node[:berkshelf_api][:home]
@@ -33,8 +37,6 @@ directory node[:berkshelf_api][:home] do
   group node[:berkshelf_api][:group]
   recursive true
 end
-
-group node[:berkshelf_api][:group]
 
 file node[:berkshelf_api][:config_path] do
   content JSON.generate(node[:berkshelf_api][:config].to_hash)

--- a/cookbook/recipes/app.rb
+++ b/cookbook/recipes/app.rb
@@ -22,9 +22,7 @@ include_recipe "runit"
 
 chef_gem "bundler"
 
-unless node[:berkshelf_api][:group] == node[:berkshelf_api][:owner]
-  group node[:berkshelf_api][:group]
-end
+group node[:berkshelf_api][:group]
 
 user node[:berkshelf_api][:owner] do
   gid node[:berkshelf_api][:group]


### PR DESCRIPTION
Small fix to ensure that the [berkshelf_api][:owner] user is created with [berkshelf_api][:group] as primary group (if they have a differing value). This requires that this group already exists before creating the user.
