### PR TITLE
Adding cookbook support for other init styles (just Upstart for now).

### DIFF
--- a/cookbook/attributes/default.rb
+++ b/cookbook/attributes/default.rb
@@ -30,3 +30,4 @@ default[:berkshelf_api][:config_path]    = "#{node[:berkshelf_api][:home]}/confi
 default[:berkshelf_api][:config]         = {
   home_path: node[:berkshelf_api][:home]
 }
+default[:berkshelf_api][:init_style] = "runit"

--- a/cookbook/recipes/app.rb
+++ b/cookbook/recipes/app.rb
@@ -18,7 +18,7 @@
 #
 
 include_recipe "libarchive::default"
-include_recipe "runit"
+include_recipe "runit" if node[:berkshelf_api][:init_style] == "runit"
 
 chef_gem "bundler"
 
@@ -53,7 +53,13 @@ libarchive_file "berkshelf-api.tar.gz" do
   group node[:berkshelf_api][:group]
 
   action :extract
-  notifies :restart, "runit_service[berks-api]"
+
+  if node[:berkshelf_api][:init_style] == "runit"
+    notifies :restart, "runit_service[berks-api]"
+  else
+    notifies :restart, "service[berks-api]"
+  end
+
   only_if { ::File.exist?(asset.asset_path) }
 end
 
@@ -65,7 +71,21 @@ execute "berkshelf-api-bundle-install" do
   not_if "cd #{node[:berkshelf_api][:deploy_path]} && /opt/chef/embedded/bin/bundle check"
 end
 
-runit_service "berks-api" do
-  sv_timeout 30
-  action :enable
+case node[:berkshelf_api][:init_style]
+when "runit"
+  runit_service "berks-api" do
+    sv_timeout 30
+    action :enable
+  end
+when "upstart"
+  template "/etc/init/berks-api.conf" do
+    source "upstart-berks-api.conf.erb"
+    mode 0644
+  end
+
+  service "berks-api" do
+    provider Chef::Provider::Service::Upstart
+    supports :restart => true, :status => true
+    action [:enable, :start]
+  end
 end

--- a/cookbook/templates/default/upstart-berks-api.conf.erb
+++ b/cookbook/templates/default/upstart-berks-api.conf.erb
@@ -1,0 +1,19 @@
+description "berks-api service"
+
+start on (net-device-up
+and local-filesystems
+and runlevel [2345])
+
+stop on runlevel [!2345]
+
+expect fork
+setuid <%= node[:berkshelf_api][:owner] %>
+console none
+
+script
+  export PATH=/opt/chef/embedded/bin:$PATH
+  export HOME=<%= node[:berkshelf_api][:deploy_path] %>
+  cd $HOME
+
+  bundle exec bin/berks-api -p <%= node[:berkshelf_api][:port] %> -c <%= node[:berkshelf_api][:config_path] %>
+end script


### PR DESCRIPTION
This adds an additional attribute that allows users to choose an init style. Runit remains the default, so backwards compatibility is preserved. I've added support for Upstart, but others could be easily implemented, as well.

Part of the motivation for this stems from also experiencing the intermittent crashing @joelmoss described in https://github.com/berkshelf/berkshelf-api/issues/121. 

Tested on Ubuntu 12.04 and 14.04.
