### PR TITLE
Cookbook metadata should not depend on the berkshelf gem

### DIFF
--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -1,14 +1,10 @@
-lib = File.expand_path('../../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'berkshelf/api/version'
-
 name             "berkshelf-api-server"
 maintainer       "Jamie Winsor"
 maintainer_email "jamie@vialstudios.com"
 license          "Apache 2.0"
 description      "Installs/Configures a berkshelf-api server"
 long_description "Installs/Configures a berkshelf-api server"
-version          Berkshelf::API::VERSION
+version          "2.1.0"
 
 %w{ redhat centos ubuntu }.each do |os|
   supports os


### PR DESCRIPTION
Testing the chef supermarket cookbook berkshelf-api-server with test-kitchen, chef_zero and vagrant cannot be performed due to the following problem.  I have set up a testing environment for berkshelf-api-server with test-kitchen.  The configuration I used is [shown on gist](https://gist.github.com/umireon/e37ba64f2d475f9cb079).  With the configuration, running the test by test-kitchen immediately failed and emitting following confusing error message:

```
Running handlers:
[2015-01-01T06:43:31+00:00] ERROR: Running exception handlers
Running handlers complete
[2015-01-01T06:43:31+00:00] ERROR: Exception handlers complete
[2015-01-01T06:43:31+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
Chef Client failed. 0 resources updated in 3.866940327 seconds
[2015-01-01T06:43:31+00:00] ERROR: undefined method `values' for "":String
[2015-01-01T06:43:33+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

The full execution log is [shown on gist](https://gist.github.com/umireon/e37ba64f2d475f9cb079#file-kitchen-converge-log).  After several surveys, I found something wrong with metadata.rb in the cookbook berkshelf-api-server.  In fact, `require 'berkshelf/api/version'` in metadata.rb raises `LoadError` like this:

```
#<LoadError: cannot load such file -- berkshelf/api/version>
```

(this was retrieved by evil way of adding `begin ... rescue ... end` and `IO.write` in metadata.rb :) )
Current test-kitchen installs chef-client 12.0.3 in testing VM and [further inspectation](https://gist.github.com/umireon/e37ba64f2d475f9cb079#file-chef-client-gems-12-0-3-log) revealed that chef-client 12.0.3 does not includes berkshelf gem. It suggests that berkshelf-api-server failed to run because it requires not yet installed gem.

This PR is to remove dependency on `berkshelf/api/version` from metadata.rb in the cookbook berkshelf-api-server.  Because metadata.rb is loaded in the very first stage of chef-client local mode execution, it cannot be avoided by prepending the berkshelf installation in node run_list.
