### PR TITLE
Modified chpst to su in init file

### DIFF
--- a/cookbook/templates/default/sv-berks-api-run.erb
+++ b/cookbook/templates/default/sv-berks-api-run.erb
@@ -5,4 +5,4 @@ export HOME=<%= node[:berkshelf_api][:deploy_path] %>
 cd $HOME
 
 exec 2>&1
-exec chpst -u <%= node[:berkshelf_api][:owner] %> bundle exec bin/berks-api -p <%= node[:berkshelf_api][:port] %> -c <%= node[:berkshelf_api][:config_path] %>
+exec su <%= node[:berkshelf_api][:owner] %> -c 'bundle exec bin/berks-api -p <%= node[:berkshelf_api][:port] %> -c <%= node[:berkshelf_api][:config_path] %>'


### PR DESCRIPTION
`chpst` does not load secondary groups, which makes granting the service permissions for files (e.g. `client.pem`) very hard
su exists on virtually all Linux systems, so should be OK
