### PR TITLE
also provide Apache as an http-proxy

### DIFF
--- a/cookbook/.gitignore
+++ b/cookbook/.gitignore
@@ -13,3 +13,4 @@ pkg/
 Gemfile.lock
 bin/*
 .bundle/*
+.kitchen/*

--- a/cookbook/.kitchen.yml
+++ b/cookbook/.kitchen.yml
@@ -1,0 +1,31 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: debian-7.4
+    run_list:
+      - recipe[hostupgrade]
+    attributes:
+      hostupgrade:
+        compile_time: true
+
+suites:
+  - name: default
+    run_list:
+      - recipe[berkshelf-api-server]
+    attributes:
+      berkshelf_api:
+        proxy_server: 'apache'
+        config:
+          endpoints:
+            - type: chef_server
+              options:
+                url: "https://chef.myorg.com"
+                client_key: "/etc/berkshelf/api-server/client.pem"
+                client_name: "berkshelf"
+          build_interval: 5.0
+        host: berkshelf.myorg.com

--- a/cookbook/.kitchen.yml
+++ b/cookbook/.kitchen.yml
@@ -27,5 +27,7 @@ suites:
                 url: "https://chef.myorg.com"
                 client_key: "/etc/berkshelf/api-server/client.pem"
                 client_name: "berkshelf"
+                ssl_certificate: '/etc/pki/tls/star.myorg.com.crt'
+                ssl_key: '/etc/pki/tls/star.myorg.com.key'
           build_interval: 5.0
         host: berkshelf.myorg.com

--- a/cookbook/attributes/default.rb
+++ b/cookbook/attributes/default.rb
@@ -29,5 +29,7 @@ default[:berkshelf_api][:proxy_server]   = 'nginx'
 default[:berkshelf_api][:host]           = node[:fqdn]
 default[:berkshelf_api][:config_path]    = "#{node[:berkshelf_api][:home]}/config.json"
 default[:berkshelf_api][:config]         = {
-  home_path: node[:berkshelf_api][:home]
+  home_path: node[:berkshelf_api][:home],
+  ssl_certificate: '/etc/pki/tls/certificate.crt',
+  ssl_key: '/etc/pki/tls/certificate.com.key'
 }

--- a/cookbook/attributes/default.rb
+++ b/cookbook/attributes/default.rb
@@ -25,6 +25,7 @@ default[:berkshelf_api][:home]           = "/etc/berkshelf/api-server"
 default[:berkshelf_api][:deploy_path]    = "/opt/berkshelf-api/#{node[:berkshelf_api][:release]}"
 default[:berkshelf_api][:port]           = 26200
 default[:berkshelf_api][:proxy_port]     = 80
+default[:berkshelf_api][:proxy_server]   = 'nginx'
 default[:berkshelf_api][:host]           = node[:fqdn]
 default[:berkshelf_api][:config_path]    = "#{node[:berkshelf_api][:home]}/config.json"
 default[:berkshelf_api][:config]         = {

--- a/cookbook/recipes/http_proxy.rb
+++ b/cookbook/recipes/http_proxy.rb
@@ -16,19 +16,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+case node[:berkshelf_api][:proxy_server]
+when 'nginx'
 
-node.set[:nginx][:install_method] = "source"
-include_recipe "nginx"
+  node.set[:nginx][:install_method] = "source"
+  include_recipe "nginx"
 
-nginx_site "default" do
-  enable false
-end
+  nginx_site "default" do
+    enable false
+  end
 
-template "#{node[:nginx][:dir]}/sites-available/berks-api" do
-  source "berks-api-nginx.erb"
-  notifies :reload, "service[nginx]"
-end
+  template "#{node[:nginx][:dir]}/sites-available/berks-api" do
+    source "berks-api-nginx.erb"
+    notifies :reload, "service[nginx]"
+  end
 
-nginx_site "berks-api" do
-  enable true
+  nginx_site "berks-api" do
+    enable true
+  end
+when 'apache'
+  include_recipe 'apache2'
+
+  web_app "#{node[:berkshelf_api][:host]}" do
+    server_name node[:berkshelf_api][:host]
+    server_aliases [node[:berkshelf_api][:host]]
+    docroot nil
+    template 'apache.conf.erb'
+  end
 end

--- a/cookbook/templates/default/apache.conf.erb
+++ b/cookbook/templates/default/apache.conf.erb
@@ -65,7 +65,7 @@
     RewriteRule ^.*$ /system/maintenance.html [L]
     
     SSLEngine on
-    SSLCertificateFile /etc/pki/tls/star.showmobile.com.crt
-    SSLCertificateKeyFile /etc/pki/tls/star.showmobile.com.key
+    SSLCertificateFile <%= @node[:berkshelf_api][:config][:ssl_certificate] %>
+    SSLCertificateKeyFile <%= @node[:berkshelf_api][:config][:ssl_key] %>
     
 </VirtualHost>

--- a/cookbook/templates/default/apache.conf.erb
+++ b/cookbook/templates/default/apache.conf.erb
@@ -1,0 +1,71 @@
+<VirtualHost *:80>
+    ServerName <%= @params[:server_name] %>
+    ServerAlias <% @params[:server_aliases] && @params[:server_aliases].each do |a| %><%= a %> <% end %>
+
+    ProxyPreserveHost On
+    <Location />
+        ProxyPass http://127.0.0.1:<%= @node[:berkshelf_api][:port] %>/
+        ProxyPassReverse http://127.0.0.1:<%= @node[:berkshelf_api][:port] %>/
+        Order Deny,Allow
+        Allow from all
+    </Location>
+    
+    <Location /server-status>
+        SetHandler server-status
+        
+        Order Deny,Allow
+        Deny from all
+        Allow from 127.0.0.1
+    </Location>
+    
+    LogLevel info
+    ErrorLog <%= @node[:apache][:log_dir] %>/<%= @params[:name] %>-error.log
+    CustomLog <%= @node[:apache][:log_dir] %>/<%= @params[:name] %>-access.log combined
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName <%= @params[:server_name] %>
+    ServerAlias <% @params[:server_aliases].each do |a| %><%= a %> <% end %>
+    RewriteEngine On
+    
+    ProxyPreserveHost On
+    <Location />
+        Order Deny,Allow
+        Allow from all
+        SSLRequireSSL
+        ProxyPass http://127.0.0.1:<%= @node[:berkshelf_api][:port] %>/
+        ProxyPassReverse http://127.0.0.1:<%= @node[:berkshelf_api][:port] %>/
+        RequestHeader set X-FORWARDED-PROTOCOL ssl
+        RequestHeader set X-FORWARDED-SSL on
+    </Location>
+    
+    <Location /server-status>
+        SetHandler server-status
+        
+        Order Deny,Allow
+        Deny from all
+        Allow from 127.0.0.1
+    </Location>
+    
+    LogLevel info
+    ErrorLog <%= node['apache']['log_dir'] %>/<%= @params[:name] %>-error.log
+    CustomLog <%= node['apache']['log_dir'] %>/<%= @params[:name] %>-access.log combined
+    
+    RewriteEngine On
+    RewriteLog <%= node['apache']['log_dir'] %>/<%= @application_name %>-rewrite.log
+    RewriteLogLevel 0
+    
+    # Canonical host, <%= @params[:server_name] %>
+    RewriteCond %{HTTP_HOST}   !^<%= @params[:server_name] %> [NC]
+    RewriteCond %{HTTP_HOST}   !^$
+    RewriteRule ^/(.*)$        http://<%= @params[:server_name] %>/$1 [L,R=301]
+    
+    RewriteCond %{DOCUMENT_ROOT}/system/maintenance.html -f
+    RewriteCond %{SCRIPT_FILENAME} !maintenance.html
+    RewriteRule ^.*$ /system/maintenance.html [L]
+    
+    SSLEngine on
+    SSLCertificateFile /etc/pki/tls/star.showmobile.com.crt
+    SSLCertificateKeyFile /etc/pki/tls/star.showmobile.com.key
+    
+</VirtualHost>


### PR DESCRIPTION
i'm throwing berkshelf on a shared-web server that has apache doing vhost-based routing, so this works better for me than running nginx on a different port and supporting two systems doing the same thing
