### PR TITLE
Attribute for optional github token

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -30,6 +30,12 @@ Installs/Configures a berkshelf-api server
     <td><tt>v{cookbook_version}</tt></td>
   </tr>
   <tr>
+    <td><tt>[:berkshelf_api][:token]</tt></td>
+    <td>String</td>
+    <td>Optional github token (https://developer.github.com/v3/#rate-limiting)</td>
+    <td><tt>nil</tt></td>
+  </tr>
+  <tr>
     <td><tt>[:berkshelf_api][:owner]</tt></td>
     <td>String</td>
     <td>Owner of the deployed application files</td>

--- a/cookbook/attributes/default.rb
+++ b/cookbook/attributes/default.rb
@@ -18,6 +18,7 @@
 #
 
 default[:berkshelf_api][:repo]           = "berkshelf/berkshelf-api"
+default[:berkshelf_api][:token]          = nil
 default[:berkshelf_api][:release]        = "v#{Berkshelf::API::Chef.cookbook_version(run_context)}"
 default[:berkshelf_api][:owner]          = "berkshelf"
 default[:berkshelf_api][:group]          = "berkshelf"

--- a/cookbook/recipes/app.rb
+++ b/cookbook/recipes/app.rb
@@ -43,6 +43,7 @@ end
 asset = github_asset "berkshelf-api.tar.gz" do
   repo node[:berkshelf_api][:repo]
   release node[:berkshelf_api][:release]
+  github_token node[:berkshelf_api][:token] unless node[:berkshelf_api][:token].nil?
 end
 
 libarchive_file "berkshelf-api.tar.gz" do


### PR DESCRIPTION
Unauthenticated API requests via the github_asset LWRP might hit the rate limit described @ https://developer.github.com/v3/#rate-limiting. For these cases, a Personal Access Token should be created and added as attribute to node[:berkshelf_api][:token] - which will allow the cookbook to run. 
