### PR TITLE
Allow nginx install method to be changed

### DIFF
--- a/cookbook/attributes/nginx.rb
+++ b/cookbook/attributes/nginx.rb
@@ -1,0 +1,1 @@
+default[:nginx][:install_method] = 'source'

--- a/cookbook/recipes/http_proxy.rb
+++ b/cookbook/recipes/http_proxy.rb
@@ -17,7 +17,6 @@
 # limitations under the License.
 #
 
-node.set[:nginx][:install_method] = "source"
 include_recipe "nginx"
 
 nginx_site "default" do


### PR DESCRIPTION
Default method is to install from source, this remains the same, however this change will allow
users of the cookbook to opt to install nginx from packages should they wish through overriding the default attribute setting.
