### PR TITLE
Generic artefact URL

### DIFF
--- a/cookbook/attributes/default.rb
+++ b/cookbook/attributes/default.rb
@@ -18,7 +18,6 @@
 #
 
 default[:berkshelf_api][:repo]           = "berkshelf/berkshelf-api"
-default[:berkshelf_api][:token]          = nil
 default[:berkshelf_api][:release]        = "v#{Berkshelf::API::Chef.cookbook_version(run_context)}"
 default[:berkshelf_api][:owner]          = "berkshelf"
 default[:berkshelf_api][:group]          = "berkshelf"
@@ -27,6 +26,7 @@ default[:berkshelf_api][:deploy_path]    = "/opt/berkshelf-api/#{node[:berkshelf
 default[:berkshelf_api][:port]           = 26200
 default[:berkshelf_api][:proxy_port]     = 80
 default[:berkshelf_api][:host]           = node[:fqdn]
+default[:berkshelf_api][:artifact_url]   = "https://github.com/berkshelf/berkshelf-api/releases/download/#{node[:berkshelf_api][:release]}/berkshelf-api.tar.gz"
 default[:berkshelf_api][:config_path]    = "#{node[:berkshelf_api][:home]}/config.json"
 default[:berkshelf_api][:config]         = {
   home_path: node[:berkshelf_api][:home]

--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -17,5 +17,4 @@ end
 depends "runit"
 depends "build-essential", ">= 2.0.2"
 depends "nginx",           ">= 1.7.0"
-depends "libarchive",      "~> 0.4"
-depends "github",          "~> 0.3"
+depends 'ark',             '0.9.0'

--- a/cookbook/recipes/app.rb
+++ b/cookbook/recipes/app.rb
@@ -17,7 +17,6 @@
 # limitations under the License.
 #
 
-include_recipe "libarchive::default"
 include_recipe "runit"
 
 chef_gem "bundler"
@@ -40,22 +39,13 @@ file node[:berkshelf_api][:config_path] do
   content JSON.generate(node[:berkshelf_api][:config].to_hash)
 end
 
-asset = github_asset "berkshelf-api.tar.gz" do
-  repo node[:berkshelf_api][:repo]
-  release node[:berkshelf_api][:release]
-  github_token node[:berkshelf_api][:token] unless node[:berkshelf_api][:token].nil?
-end
-
-libarchive_file "berkshelf-api.tar.gz" do
-  path asset.asset_path
-  extract_to node[:berkshelf_api][:deploy_path]
-  extract_options :no_overwrite
+ark node[:berkshelf_api][:release] do
   owner node[:berkshelf_api][:owner]
   group node[:berkshelf_api][:group]
-
-  action :extract
-  notifies :restart, "runit_service[berks-api]"
-  only_if { ::File.exist?(asset.asset_path) }
+  url "#{node[:berkshelf_api][:home]}/berkshelf-api.tar.gz"
+  prefix_root '/opt/berkshelf-api/'
+  action :put
+  notifies :restart, 'runit_service[berks-api]'
 end
 
 execute "berkshelf-api-bundle-install" do

--- a/cookbook/recipes/app.rb
+++ b/cookbook/recipes/app.rb
@@ -42,7 +42,7 @@ end
 ark node[:berkshelf_api][:release] do
   owner node[:berkshelf_api][:owner]
   group node[:berkshelf_api][:group]
-  url "#{node[:berkshelf_api][:home]}/berkshelf-api.tar.gz"
+  url node[:berkshelf_api][:artifact_url]
   prefix_root '/opt/berkshelf-api/'
   action :put
   notifies :restart, 'runit_service[berks-api]'


### PR DESCRIPTION
Fixes 
- libarchive issues #187  #167 

Makes the resource more generic so people can override the github url with an internal artifact repository. 
