### PR TITLE
This will remove default.conf from /etc/nginx/conf.d as with new rele…

### DIFF
--- a/cookbook/recipes/http_proxy.rb
+++ b/cookbook/recipes/http_proxy.rb
@@ -20,8 +20,8 @@
 node.set[:nginx][:install_method] = "source"
 include_recipe "nginx"
 
-nginx_site "default" do
-  enable false
+file "/etc/nginx/conf.d/default.conf" do
+  action :delete
 end
 
 template "#{node[:nginx][:dir]}/sites-available/berks-api" do


### PR DESCRIPTION
…ase of nginx cookbook, it is impossible to switch off default.conf with enable/disable.
Here is change log of nginx cookbook from opsecode:
CHANGELOG.md:- [COOK-2398]: nginx_site definition cannot be used to manage the default site
