### PR TITLE
Loosening Octokit version constraint so it doesn't conflict with 4.0.1 of Berkshelf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  #- 1.9.3
+  - 1.9.3
   - 2.0.0
   - 2.1
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3
+  #- 1.9.3
   - 2.0.0
   - 2.1
 notifications:

--- a/berkshelf-api.gemspec
+++ b/berkshelf-api.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hashie',         '>= 2.0.4', '< 4.0.0'
   spec.add_dependency 'archive',        '= 0.0.6'
   spec.add_dependency 'buff-config',    '~> 1.0'
-  spec.add_dependency 'octokit',        '~> 4.0'
+  spec.add_dependency 'octokit',        '>= 3.0.0', '< 5.0.0'
   spec.add_dependency 'semverse',       '~> 1.0'
 end

--- a/berkshelf-api.gemspec
+++ b/berkshelf-api.gemspec
@@ -30,4 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'buff-config',    '~> 1.0'
   spec.add_dependency 'octokit',        '>= 3.0.0', '< 5.0.0'
   spec.add_dependency 'semverse',       '~> 1.0'
+  # varia_mode 0.5 depends on Ruby 2.x - we can update to that
+  # when we are prepared to bump our own required_ruby_version
+  spec.add_dependency 'varia_model',    '>= 0.4.0', '< 0.5.0'
 end


### PR DESCRIPTION
\cc @jkeiser @reset
