### PR TITLE
Using faraday because it obeys no_proxy

### DIFF
--- a/berkshelf-api.gemspec
+++ b/berkshelf-api.gemspec
@@ -33,4 +33,6 @@ Gem::Specification.new do |spec|
   # varia_mode 0.5 depends on Ruby 2.x - we can update to that
   # when we are prepared to bump our own required_ruby_version
   spec.add_dependency 'varia_model',    '>= 0.4.0', '< 0.5.0'
+  spec.add_dependency 'faraday',        '~> 0.9.0'
+  spec.add_dependency 'httpclient',     '~> 2.7.0'
 end

--- a/lib/berkshelf/api/site_connector/supermarket.rb
+++ b/lib/berkshelf/api/site_connector/supermarket.rb
@@ -55,7 +55,8 @@ module Berkshelf::API
             faraday.response :logger
             faraday.adapter  :httpclient
           end
-          JSON.parse(response.get.body)d
+          JSON.parse(response.get.body)
+	end
       rescue JSON::ParserError => e
         log.error "Failed to parse JSON: #{e}"
         EMPTY_UNIVERSE

--- a/lib/berkshelf/api/site_connector/supermarket.rb
+++ b/lib/berkshelf/api/site_connector/supermarket.rb
@@ -1,6 +1,7 @@
 require 'open-uri'
 require 'archive'
 require 'tempfile'
+require 'faraday'
 
 module OpenURI
   class << self
@@ -49,9 +50,12 @@ module Berkshelf::API
         log.debug "Loading universe from `#{universe_url}'..."
 
         Timeout.timeout(TIMEOUT) do
-          response = open(universe_url, 'User-Agent' => USER_AGENT)
-          JSON.parse(response.read)
-        end
+          response =  Faraday.new(url: universe_url) do |faraday|
+            faraday.request  :url_encoded
+            faraday.response :logger
+            faraday.adapter  :httpclient
+          end
+          JSON.parse(response.get.body)d
       rescue JSON::ParserError => e
         log.error "Failed to parse JSON: #{e}"
         EMPTY_UNIVERSE


### PR DESCRIPTION
This will make berkshelf-api server obey the no_proxy variable, which is a feature we need here badly.

I have no real way to test this in a different way than I have for this: I have added the faraday stuff to supermarket.rb and installed the missing gems and it works as expected. 
