### PR TITLE
manual hackery to bump travis version for now

### DIFF
--- a/cookbook/.kitchen.travis.yml
+++ b/cookbook/.kitchen.travis.yml
@@ -52,4 +52,4 @@ suites:
   - name: default
     run_list:
       - recipe[berkshelf-api-server]
-    attributes: { berkshelf_api: { release: "v2.1.1" } }
+    attributes: { berkshelf_api: { release: "v2.2.0" } }

--- a/cookbook/.kitchen.yml
+++ b/cookbook/.kitchen.yml
@@ -20,4 +20,4 @@ suites:
   - name: default
     run_list:
       - recipe[berkshelf-api-server]
-    attributes: { berkshelf_api: { release: "v2.1.1" } }
+    attributes: { berkshelf_api: { release: "v2.2.0" } }


### PR DESCRIPTION
somehow we need to figure out how to test travis against the
checked out version of the cookbook and not go to github to download
a release tarball that doesn't exist yet...
